### PR TITLE
Fix tags in edit form

### DIFF
--- a/food_db/food_db_app/templates/add_edit_recipe.html
+++ b/food_db/food_db_app/templates/add_edit_recipe.html
@@ -13,7 +13,7 @@
                     {% for value, text in create_recipe_form.tags.field.choices %}
                     
                         <div class="ui slider checkbox tag_check">
-                            <input id="id_tags_{{ forloop.counter0 }}" type="checkbox" value="{{ value }}"{% if text in checked_tags %} checked="checked"{% endif %}>
+                            <input id="id_tags_{{ forloop.counter0 }}" name="tag" type="checkbox" value="{{ text }}"{% if text in checked_tags %} checked="checked"{% endif %}>
                             {{ text }}
                         </div>
                         <!-- {% if forloop.counter|divisibleby:2 %}</ul><ul>{% endif %} -->

--- a/food_db/food_db_app/tests/test_views.py
+++ b/food_db/food_db_app/tests/test_views.py
@@ -159,6 +159,32 @@ class ViewTests(TestCase):
         self.assertEqual(Ingredient.objects.filter(recipe=recipe_instance).count(), 2)
         self.assertEqual(RecipeStep.objects.filter(recipe=recipe_instance).count(), 2)
 
+    def test_edit_recipe_add_tag_POST(self):
+        title = 'My recipe'
+        recipe_instance = Recipe.objects.get(title=title)
+        
+        # add tags
+        Tag.objects.create(name='winter')
+        Tag.objects.create(name='autumn')
+
+        self.assertEqual(Tag.objects.filter(recipes=recipe_instance).count(), 0)
+
+        # this removes the link between recipe book and the recipe, and adds ingredients, steps, foods, and units
+        post_data = {
+            'title': title,
+            'tag': ['winter'],
+            'servings': '',  # servings is required here because it gets passed into the cleaning function of the form
+            'extra_ingred_count': 0,
+            'extra_step_count': 0,
+        }
+        response = self.client.post(
+            self.edit_recipe(title),
+            data=post_data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(Tag.objects.filter(recipes=recipe_instance).count(), 1)
+        self.assertEqual(Tag.objects.get(recipes=recipe_instance).name, 'winter')
+
     def test_new_tag_POST(self):
         self.assertEqual(Tag.objects.all().count(), 0)
         post_data = {

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -261,7 +261,7 @@ def edit_recipe(request, title):
                 tag.save()
             
             # Extract tags from form data and create new relationships from tag -> recipe
-            tags = create_recipe_form.cleaned_data['tags']
+            tags = request.POST.getlist('tag')
             if tags:
                 for tag in tags:
                     tag_instance = Tag.objects.get(name=tag)


### PR DESCRIPTION
The edit form would wipe tags every time because they weren't in "cleaned_data". Adding a name to the `<input>` elements allowed me to get them from the post request. Put a test in as well.