### PR TITLE
Step parse

### DIFF
--- a/food_db/food_db_app/templates/add_edit_recipe.html
+++ b/food_db/food_db_app/templates/add_edit_recipe.html
@@ -138,7 +138,7 @@
                 <td width="20%"><input type="text" name="ingred_{{ forloop.counter0 }}_ingredient_category" id="id_ingred_{{ forloop.counter0 }}_ingredient_category" value="{{ ingred.ingredient_category }}"></td>
                 <td width="20%"><input type="text" name="ingred_{{ forloop.counter0 }}_notes" id="id_ingred_{{ forloop.counter0 }}_notes" value="{{ ingred.notes }}"></td>
                 <td><a style="cursor: pointer;" onmouseover="">
-                    <img class="delete_ingred_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" alt="Delete row"/>
+                    <img class="delete_ingred_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" title="Delete row"/>
                 </a></td>
             </tr>
             {% endfor %}

--- a/food_db/food_db_app/templates/add_edit_recipe.html
+++ b/food_db/food_db_app/templates/add_edit_recipe.html
@@ -115,6 +115,7 @@
                 <th width="35%">Food</th>
                 <th width="20%">Category</th>
                 <th width="20%">Notes</th>
+                <th> </th>
             </tr>
             {% for ingred in ingredient_list %}
             <tr name="ingred_{{ forloop.counter0 }}_row">
@@ -137,7 +138,7 @@
                 <td width="20%"><input type="text" name="ingred_{{ forloop.counter0 }}_ingredient_category" id="id_ingred_{{ forloop.counter0 }}_ingredient_category" value="{{ ingred.ingredient_category }}"></td>
                 <td width="20%"><input type="text" name="ingred_{{ forloop.counter0 }}_notes" id="id_ingred_{{ forloop.counter0 }}_notes" value="{{ ingred.notes }}"></td>
                 <td><a style="cursor: pointer;" onmouseover="">
-                    <img id="delete_ingred_button" onclick="removeThisIngredientRow(this)" src="{% static 'img/x-icon.svg' %}" width="20" height="20" alt="Delete row"/>
+                    <img class="delete_ingred_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" alt="Delete row"/>
                 </a></td>
             </tr>
             {% endfor %}
@@ -158,7 +159,7 @@
 
     <h2>Recipe</h2>
     {{create_recipe_form.extra_step_count}}
-    <table id="step-table" class="form-table">
+    <table id="step_table" class="form-table">
         {% for step in step_list %}
         <tr>
             <div class="step-form">
@@ -166,6 +167,9 @@
                     <textarea name="step_{{ forloop.counter0 }}_description" id="id_step_{{ forloop.counter0 }}_description">{{ step.description }}</textarea>
                     <span id="step_{{ forloop.counter0 }}_description_tooltip" class="form_validate_tooltip">You must specify at least one recipe step</span>
                 </td>
+                <td class="step_x_icon"><a style="cursor: pointer;" onmouseover="">
+                    <img class="delete_step_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" alt="Delete step"/>
+                </a></td>
             </div>
         </tr>
         {% endfor %}

--- a/food_db/food_db_app/templates/add_edit_recipe.html
+++ b/food_db/food_db_app/templates/add_edit_recipe.html
@@ -167,8 +167,9 @@
                     <textarea name="step_{{ forloop.counter0 }}_description" id="id_step_{{ forloop.counter0 }}_description">{{ step.description }}</textarea>
                     <span id="step_{{ forloop.counter0 }}_description_tooltip" class="form_validate_tooltip">You must specify at least one recipe step</span>
                 </td>
-                <td class="step_x_icon"><a style="cursor: pointer;" onmouseover="">
-                    <img class="delete_step_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" alt="Delete step"/>
+                <td class="step_row_buttons"><a style="cursor: pointer;" onmouseover="">
+                    <img class="delete_step_button" src="{% static 'img/x-icon.svg' %}" width="20" height="20" title="Delete step"/>
+                    <i class="fa-solid fa-ellipsis parse_step_button" title="Parse bulk text into separate steps"></i>
                 </a></td>
             </div>
         </tr>

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -183,16 +183,26 @@ input[type="url"] {
 
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
-    .step_x_icon {
+    .step_row_buttons {
         width: 4%;
     }
 }
 /* When screen is less than 600 px wide */
 @media screen and (max-width: 599px) {
-    .step_x_icon {
+    .step_row_buttons {
         width: 12%;
     }
 }
+.step_row_buttons {
+    text-align: center;
+}
 #step_table {
     table-layout: fixed;
+}
+.delete_step_button {
+    cursor: pointer;
+}
+.parse_step_button {
+    cursor: pointer;
+    color: blue;
 }

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -184,7 +184,7 @@ input[type="url"] {
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
     .step_x_icon {
-        width: 6%;
+        width: 4%;
     }
 }
 /* When screen is less than 600 px wide */

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -72,7 +72,7 @@ span.tag_display_label.small {
         -moz-columns: 2;
     }
 }
-/* When screen is at less than 600 px wide */
+/* When screen is less than 600 px wide */
 @media screen and (max-width: 599px) {
     button.form_mod_button {
         width: 13rem;
@@ -179,4 +179,20 @@ input[type="url"] {
 }
 .search_sort_icon {
     display: none;
+}
+
+/* When screen is at least 600 px wide */
+@media screen and (min-width: 600px) {
+    .step_x_icon {
+        width: 6%;
+    }
+}
+/* When screen is less than 600 px wide */
+@media screen and (max-width: 599px) {
+    .step_x_icon {
+        width: 12%;
+    }
+}
+#step_table {
+    table-layout: fixed;
 }

--- a/food_db/static/js/add_ingredients_and_steps.js
+++ b/food_db/static/js/add_ingredients_and_steps.js
@@ -4,10 +4,21 @@
 let ingredTable = document.querySelector("#ingred-table")
 let ingredTableBody = ingredTable.querySelector('tbody')
 let addIngredientButton = document.querySelector("#add-ingred-form")
-let deleteIngredientButton = document.querySelector("#delete-ingred-form")
+let deleteLastIngredientButton = document.querySelector("#delete-ingred-form")
+let deleteThisIngredientButtons = document.querySelectorAll(".delete_ingred_button")
 
 let extraIngredRowCountField = document.querySelector("#id_extra_ingred_count")
 let extraIngredRowNum = Number(extraIngredRowCountField.value);
+
+function addListenersToRowButtons() {
+    let deleteThisIngredientButtons = document.querySelectorAll(".delete_ingred_button")
+    let deleteThisStepButtons = document.querySelectorAll(".delete_step_button")
+
+    deleteThisIngredientButtons.forEach(btn => btn.addEventListener('click', removeThisIngredientRow, btn))
+    deleteThisStepButtons.forEach(btn => btn.addEventListener('click', removeThisStepRow, btn))
+}
+
+addListenersToRowButtons()
 
 function addIngredientRow(e) {
     e.preventDefault()
@@ -27,6 +38,8 @@ function addIngredientRow(e) {
     // Increment the number of total rows in the hidden field
     extraIngredRowNum++
     extraIngredRowCountField.value = extraIngredRowNum 
+
+    addListenersToRowButtons()
 }
 
 function removeBottomIngredientRow(e) {
@@ -39,8 +52,8 @@ function removeBottomIngredientRow(e) {
     extraIngredRowCountField.value = extraIngredRowNum
 }
 
-function removeThisIngredientRow(deleteButton) {
-    let row = deleteButton.parentNode.parentNode.parentNode
+function removeThisIngredientRow(e) {
+    let row = e.currentTarget.closest('tr')
     ingredTableBody.removeChild(row)
 
     extraIngredRowNum--
@@ -48,15 +61,15 @@ function removeThisIngredientRow(deleteButton) {
 }
 
 addIngredientButton.addEventListener('click', addIngredientRow)
-deleteIngredientButton.addEventListener('click', removeBottomIngredientRow)
-
+deleteLastIngredientButton.addEventListener('click', removeBottomIngredientRow)
+deleteThisIngredientButtons.forEach(btn => btn.addEventListener('click', removeThisIngredientRow, btn))
 
 // Same thing, but now Steps
 
-let stepTable = document.querySelector("#step-table")
+let stepTable = document.querySelector("#step_table")
 let stepTableBody = stepTable.querySelector('tbody')
 let addStepButton = document.querySelector("#add-step-form")
-let deleteStepButton = document.querySelector("#delete-step-form")
+let deleteLastStepButton = document.querySelector("#delete-step-form")
 
 let extraStepRowCountField = document.querySelector("#id_extra_step_count")
 let extraStepRowNum = Number(extraStepRowCountField.value);
@@ -78,7 +91,9 @@ function addStepRow(e) {
 
     // Increment the number of total rows in the hidden field
     extraStepRowNum++
-    extraStepRowCountField.value = extraStepRowNum 
+    extraStepRowCountField.value = extraStepRowNum
+
+    addListenersToRowButtons() 
 }
 
 function removeBottomStepRow(e) {
@@ -91,8 +106,8 @@ function removeBottomStepRow(e) {
     extraStepRowCountField.value = extraStepRowNum
 }
 
-function removeThisStepRow(deleteButton) {
-    let row = deleteButton.parentNode.parentNode
+function removeThisStepRow(e) {
+    let row = e.currentTarget.closest('tr')
     stepTableBody.removeChild(row)
 
     extraStepRowNum--
@@ -100,5 +115,4 @@ function removeThisStepRow(deleteButton) {
 }
 
 addStepButton.addEventListener('click', addStepRow)
-deleteStepButton.addEventListener('click', removeBottomStepRow)
-
+deleteLastStepButton.addEventListener('click', removeBottomStepRow)


### PR DESCRIPTION
- Modify JS behind the in-row ingredient delete buttons (red X) so it uses `closest` instead of `.parentNode.parentNode.parentNode`, and so the event listener is assigned in JS rather than in HTML
- Make the same changes to the in-row step delete button JS, which had been written even though no buttons had yet been created
- Create said buttons with the red X icon so we can now delete individual steps
- Updates row insertion for both ingredients and steps to find the _highest_ ID and increment that, rather than assuming the last row is the highest
- Updates row insertion to only insert blank rows, rather than the values of the first row

But most importantly, I added `...` buttons next to each step textbox, and connected those to a JS function that parses the text, throws away the blanks and the numbers (e.g. `1. `), and creates/populates step textboxes with the results