### PR TITLE
Allow for use of Markdown in step descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ First and foremost, as long as the Docker images are running, you can access you
 Another option is [cloud sync](food_db/food_db_app/cloud_sync/README.md). When enabled, your recipes are backed up to a read-only site hosted in S3. Though you lose basically all the functionality of FoodDB, it's a nice compromise to be able to securely access your recipes when away from home and even when FoodDB is taken offline.
 
 ### Port forwarding
-You have two options when port forwarding - open up to any computer/phone/dog that's connected to your wifi network, or open up to _anyone, anywhere_. Obviously, the latter is more dangerous. I am not a security expert and I know I have made a few compromises (search the repo for `csrf_exempt` 😅) in my Django security.
+You have two options when port forwarding - open up to any computer/phone/dog that's connected to your wifi network, or open up to _anyone, anywhere_. Obviously, the latter is more dangerous. I am not a security expert and I know I have made a few compromises (search the repo for `csrf_exempt` or check out the use of `| safe` on a user input on the recipe detail page 😅) in my Django security.
 
 That said, if you open up to the world, you can access Food DB from anywhere. At the grocery store and trying to decide what to eat? Log into Food DB from your phone! If that sounds good to you, do a little resarch on how to secure your setup. I'm not a security expert and my own site is not open to the public internet.
 

--- a/food_db/django-requirements.txt
+++ b/food_db/django-requirements.txt
@@ -3,5 +3,6 @@ django==5.1
 django-filter==24.3
 djangorestframework==3.15.2
 fontawesomefree==6.6.0
+markdown==3.7
 pytz==2024.2
 requests

--- a/food_db/food_db_app/templates/recipe_detail.html
+++ b/food_db/food_db_app/templates/recipe_detail.html
@@ -1,4 +1,5 @@
 {% extends 'main.html' %}
+{% load markdown %}
 {% load static %}
 {% block content %}
 <table>
@@ -116,7 +117,7 @@
         {% for step in steps %}
             <tr>
                 <td class="step_number">{{ step.order_number }}.</td>
-                <td class="step_description_text">{{ step.description }}</td>
+                <td class="step_description_text">{{ step.description | markdown | safe }}</td>
             </tr>
         {% endfor %}
     </table>

--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -1,0 +1,11 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+import markdown as md
+
+register = template.Library()
+
+@register.filter()
+@stringfilter
+def markdown(value):
+    return md.markdown(value, extensions=['markdown.extensions.fenced_code'])


### PR DESCRIPTION
Closes #22

Allows for more control over the formatting of step descriptions, in case you wanted to put a numbered list or bolded text inside a step, for example