### PR TITLE
Add buttons in Food Manager to edit food name and category

### DIFF
--- a/food_db/food_db_app/templates/manage_food.html
+++ b/food_db/food_db_app/templates/manage_food.html
@@ -24,24 +24,22 @@
         {% for food in foods %}
         <tr class="manage_food_row" data-food="{{ food.name }}" data-category="{{ food.category }}">
             <td>
-                <input type="text" 
+                <textarea 
                     readonly 
                     oncopy="return false"
                     oncut="return false"
                     onpaste="return false"
                     class="food_input food_name locked"
-                    value="{{ food.name }}"
-                ></input>
+                >{{ food.name }}</textarea>
             </td>
             <td>
-                <input type="text" 
+                <textarea 
                     readonly 
                     oncopy="return false"
                     oncut="return false"
                     onpaste="return false"
                     class="food_input food_category locked"
-                    value="{{ food.category }}"
-                ></input>
+                >{{ food.category }}</textarea>
             </td>
         </tr>
         {% endfor %}

--- a/food_db/food_db_app/templates/manage_food.html
+++ b/food_db/food_db_app/templates/manage_food.html
@@ -29,7 +29,7 @@
                     oncopy="return false"
                     oncut="return false"
                     onpaste="return false"
-                    class="food_input locked"
+                    class="food_input food_name locked"
                     value="{{ food.name }}"
                 ></input>
             </td>
@@ -39,7 +39,7 @@
                     oncopy="return false"
                     oncut="return false"
                     onpaste="return false"
-                    class="food_input locked"
+                    class="food_input food_category locked"
                     value="{{ food.category }}"
                 ></input>
             </td>
@@ -52,6 +52,8 @@
         <div id="food_stats_buttons">
             <button id="merge_food_button" style="display: none;" class="food_stats_button" type="button">Merge with another</button>
             <button id="cancel_merge_food_button" style="display: none;" class="food_stats_button" type="button" onclick="resetMergeMode(false, '')">Cancel Merge</button>
+            <button id="edit_food_button" style="display: none;" class="food_stats_button" type="button">Edit Row</button>
+            <button id="cancel_edit_food_button" style="display: none;" class="food_stats_button" type="button" onclick="resetEditMode(true)">Cancel Edit</button>
         </div>
         <h3 id="food_stats_merge_header"></h3>
         <span id="food_stats_merge_body"></span>

--- a/food_db/food_db_app/templates/manage_food.html
+++ b/food_db/food_db_app/templates/manage_food.html
@@ -33,13 +33,12 @@
                 >{{ food.name }}</textarea>
             </td>
             <td>
-                <textarea 
-                    readonly 
-                    oncopy="return false"
-                    oncut="return false"
-                    onpaste="return false"
-                    class="food_input food_category locked"
-                >{{ food.category }}</textarea>
+                <span class="food_category_label locked">{{ food.category }}</span>
+                <select class="food_input food_category unlocked" style="display: none;">
+                    {% for category in categories %}
+                    <option value="{{ category }}" {% if category == food.category %}selected{% endif %}>{{ category }}</option>
+                    {% endfor %}
+                </select>
             </td>
         </tr>
         {% endfor %}

--- a/food_db/food_db_app/templates/manage_food.html
+++ b/food_db/food_db_app/templates/manage_food.html
@@ -23,8 +23,26 @@
         </tr>
         {% for food in foods %}
         <tr class="manage_food_row" data-food="{{ food.name }}" data-category="{{ food.category }}">
-            <td class="food_name">{{ food.name }}</td>
-            <td class="food_category">{{ food.category }}</td>
+            <td>
+                <input type="text" 
+                    readonly 
+                    oncopy="return false"
+                    oncut="return false"
+                    onpaste="return false"
+                    class="food_input locked"
+                    value="{{ food.name }}"
+                ></input>
+            </td>
+            <td>
+                <input type="text" 
+                    readonly 
+                    oncopy="return false"
+                    oncut="return false"
+                    onpaste="return false"
+                    class="food_input locked"
+                    value="{{ food.category }}"
+                ></input>
+            </td>
         </tr>
         {% endfor %}
     </table>

--- a/food_db/food_db_app/urls.py
+++ b/food_db/food_db_app/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     # apis
     path('cook/', views.cook_meal, name='cook_meal'),
     path('delete_recipe_image/', views.delete_recipe_image, name='delete_recipe_image'),
+    path('edit_food/', views.edit_food, name='edit_food'),
     path('get_ingredient_category_order_number/', views.get_ingredient_category_order_number, name='get_ingredient_category_order_number'),
     path('ingred_parse', views.ingredient_parse_api, name='ingred_parse'),
     path('merge_foods/', views.merge_foods, name='merge_foods'),

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -15,7 +15,7 @@ from pytz import timezone
 
 from .filters import RecipeTextFilter
 from .forms import CreateRecipeForm
-from .models import CookedMeal, Food, Ingredient, Recipe, RecipeBook, RecipeStep, Tag, UnitOfMeasurement, RecipeImage, IngredientCategory
+from .models import CookedMeal, Food, Ingredient, Recipe, RecipeBook, RecipeStep, Tag, UnitOfMeasurement, RecipeImage, IngredientCategory, FoodCategory
 from .cloud_sync.s3 import S3_SYNC_ENABLED, S3Sync
 
 def convert_minutes_to_string(minutes: int):
@@ -632,8 +632,10 @@ def manage_food(request):
         }
         for food in food_instances
     ]
+    categories = [cat.name for cat in FoodCategory.objects.all().order_by('name')]
     context = {
         'foods': foods,
+        'categories': categories,
     }
     return render(request, 'manage_food.html', context)
 

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -736,3 +736,20 @@ def delete_food(request):
         return HttpResponse(status=200)
     else:
         return HttpResponseNotAllowed(permitted_methods=['POST'])
+    
+@csrf_exempt
+def edit_food(request):
+    if request.method == 'POST':
+        data = json.loads(request.body)
+        food = Food.objects.get(name=data['original_food_name'])
+        food.name = data['new_food_name']
+        category_name = data['category_name']
+        if category_name != '':
+            category = FoodCategory.objects.get(name=category_name)
+            food.food_category = category
+        else:
+            food.food_category = None
+        food.save()
+        return HttpResponse(status=200)
+    else:
+        return HttpResponseNotAllowed(permitted_methods=['POST'])

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -450,8 +450,8 @@ svg.grip-icon {
 .food_stats ul {
     padding-left: 0px;
 }
-
-.food_input {
+/* Food name */
+.food_name {
     resize: none;
     line-height: 1.3;
     padding: 0px;
@@ -461,29 +461,34 @@ svg.grip-icon {
     overflow: hidden;
     min-height: 100%;
 }
-
-textarea.locked {
+.locked {
     border-color: transparent !important;
     border: 0px;
     cursor: default;
 }
-textarea.locked:focus {
+.locked:focus {
     border-color: transparent !important;
     box-shadow: none;
     border: 0px;
 }
-
-textarea.locked::selection {
+.locked::selection {
     background-color: transparent;
     display: none;
 }
-
-
 textarea.unlocked {
     border-color: white;
     box-shadow: white;
 }
-
+/* Food category */
+.food_category_label {
+    line-height: 1.3;
+    font-size: 1rem;
+    cursor: default;
+}
+.food_category {
+    line-height: 1.3;
+    font-size: 1rem;
+}
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
     .food_stats ul {

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -447,24 +447,39 @@ svg.grip-icon {
     padding-left: 0px;
 }
 
-input[type="text"].locked {
+.food_stats ul {
+    padding-left: 0px;
+}
+
+.food_input {
+    resize: none;
+    line-height: 1.3;
+    padding: 0px;
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    overflow: hidden;
+    min-height: 100%;
+}
+
+textarea.locked {
     border-color: transparent !important;
     border: 0px;
-    cursor: auto;
+    cursor: default;
 }
-input[type="text"].locked:focus {
+textarea.locked:focus {
     border-color: transparent !important;
     box-shadow: none;
     border: 0px;
 }
 
-input[type="text"].locked::selection {
+textarea.locked::selection {
     background-color: transparent;
     display: none;
 }
 
 
-input[type="text"].unlocked {
+textarea.unlocked {
     border-color: white;
     box-shadow: white;
 }

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -463,6 +463,12 @@ input[type="text"].locked::selection {
     display: none;
 }
 
+
+input[type="text"].unlocked {
+    border-color: white;
+    box-shadow: white;
+}
+
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
     .food_stats ul {
@@ -500,7 +506,12 @@ button.merge_selected {
     color: #d9edf7;
     background-color: #610035;
 }
-#cancel_merge_food_button {
+.food_stats_button {
     margin-top: 10px;
+}
+#cancel_merge_food_button {
+    margin-bottom: 20px;
+}
+#cancel_edit_food_button {
     margin-bottom: 20px;
 }

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -447,6 +447,22 @@ svg.grip-icon {
     padding-left: 0px;
 }
 
+input[type="text"].locked {
+    border-color: transparent !important;
+    border: 0px;
+    cursor: auto;
+}
+input[type="text"].locked:focus {
+    border-color: transparent !important;
+    box-shadow: none;
+    border: 0px;
+}
+
+input[type="text"].locked::selection {
+    background-color: transparent;
+    display: none;
+}
+
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
     .food_stats ul {

--- a/food_db/static/js/manage_food.js
+++ b/food_db/static/js/manage_food.js
@@ -43,7 +43,8 @@ function getFoodData(document) {
     return returnDict
 }
 
-function autoTextareaHeight(element) {
+function autoTextareaHeight(event) {
+    element = event.target
     element.style.height = "5px";
     element.style.height = (element.scrollHeight)+"px";
 }
@@ -126,11 +127,50 @@ function resetEditMode(cancelEdits) {
 
         // no need to change any values for the Category since categoryLabel still holds the original value
         originalCategoryValue = null
+    } else {
+        originalFoodValue = null
+        originalCategoryValue = null
+        categoryLabel.innerText = categorySelect.value
     }
 }
 
 async function submitEdits() {
-    return
+    let nameInput = highlightedStatsRow.querySelector('.food_name')
+    let categorySelect = highlightedStatsRow.querySelector('.food_category')
+    editButton.innerText = 'Saving edits...'
+    editButton.setAttribute('disabled', true)
+    await fetch(`${currentUrlDomain}/edit_food/`, {
+        method: "POST",
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            original_food_name: originalFoodValue,
+            new_food_name: nameInput.value,
+            category_name: categorySelect.value,
+        })
+    })
+    .then(function(response) {
+        if ( ! response.status == 200 ) {
+            // Quit the function here
+            console.log("d'oh!")
+            return
+        }
+    })
+    // This assumes the response was 200 since it didn't return earlier
+    // Doing this so I can use await, which must be at top-level (rather than
+    // putting it under the .then function above)
+    await reloadFoodCategoryTable()
+    editButton.removeAttribute('disabled')
+    resetEditMode(false, '')
+    
+    // Reloading the table un-highlights the row, so we re-highlight it by
+    // faking a click event.
+    let newHighlightedRowIndex = foodDataDict[nameInput.value]['rowIndex']
+    let newHighlightedRow = foodCategoryTable.rows[newHighlightedRowIndex]
+    let fakeEvent = {'target': newHighlightedRow}
+    highlightStatsRow(fakeEvent)
 }
 
 const submitEditsHandler = () => submitEdits()
@@ -322,9 +362,10 @@ function assignRowListeners() {
     })
 
     let inputs = document.querySelectorAll('.food_name')
-    inputs.forEach(row => {
-        autoTextareaHeight(row)
-        row.addEventListener('change', autoTextareaHeight)
+    inputs.forEach(textarea => {
+        let fakeEvent = {'target': textarea}
+        autoTextareaHeight(fakeEvent)
+        textarea.addEventListener('change', function(event) {autoTextareaHeight(event)})
     })
 
     

--- a/food_db/static/js/manage_food.js
+++ b/food_db/static/js/manage_food.js
@@ -32,7 +32,7 @@ function getFoodData(document) {
         returnDict[food.name] = {
             'category': food.category,
             'recipes': food.recipes,
-            'rowIndex': index,
+            'rowIndex': index + 1,   // The headers are row 0 in the table, so starting the index at 1
         }
     })
     return returnDict
@@ -68,6 +68,8 @@ function highlightStatsRow(event){
     if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
         targetElement = targetElement.parentNode;   
+    } else if (targetElement.nodeName == "INPUT") {
+        targetElement = targetElement.parentNode.parentNode
     }
     if (highlightedStatsRow == targetElement) {
         // If clicking the already-highlighted row, un-highlight it and remove stats
@@ -153,7 +155,7 @@ async function mergeFoods(event) {
         // variable won't work since that is from before reloadFoodCategoryTable. 
         // Instead we'll find it by index.
         let newHighlightedRowIndex = foodDataDict[secondFood]['rowIndex']
-        let newHighlightedRow = foodCategoryTable.rows[newHighlightedRowIndex + 1]  // + 1 because the headers are row 0
+        let newHighlightedRow = foodCategoryTable.rows[newHighlightedRowIndex]
         let fakeEvent = {'target': newHighlightedRow}
         highlightStatsRow(fakeEvent)
     }
@@ -184,7 +186,9 @@ function highlightMergeRow(event) {
     targetElement = event.target
     if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
-        targetElement = targetElement.parentNode;   
+        targetElement = targetElement.parentNode
+    } else if (targetElement.nodeName == "INPUT") {
+        targetElement = targetElement.parentNode.parentNode
     }
     if (highlightedMergeRow == targetElement) {
         // If clicking the already-highlighted row, un-highlight it and remove stats
@@ -218,8 +222,11 @@ function highlightMergeRow(event) {
     }
 }
 
-function handleFoodRowClick(event) {
-    event.preventDefault()
+function handleFoodRowClick(event, preventDefault) {
+    if (preventDefault == undefined) {
+        // when this is called from handleTextInputClick, we don't need to (and can't) preventDefault again
+        event.preventDefault()
+    } 
     if (mergeMode == true) {
         highlightMergeRow(event)
     } else {

--- a/food_db/static/js/manage_food.js
+++ b/food_db/static/js/manage_food.js
@@ -43,6 +43,11 @@ function getFoodData(document) {
     return returnDict
 }
 
+function autoTextareaHeight(element) {
+    element.style.height = "5px";
+    element.style.height = (element.scrollHeight)+"px";
+}
+
 function showHideTabs(){   
     $('#tabs li a:not(:first)').addClass('inactive');
     $('.tab_container').hide();
@@ -81,8 +86,8 @@ function enterEditMode() {
         input.removeAttribute('readonly')
     })
 
-    originalFoodValue = highlightedStatsRow.querySelector('.food_name').getAttribute('value')
-    originalCategoryValue = highlightedStatsRow.querySelector('.food_category').getAttribute('value')
+    originalFoodValue = highlightedStatsRow.querySelector('.food_name').value
+    originalCategoryValue = highlightedStatsRow.querySelector('.food_category').value
 
     editButton.removeEventListener('click', enterEditMode)
     editButton.addEventListener('click', submitEditsHandler)
@@ -110,8 +115,10 @@ function resetEditMode(cancelEdits) {
 
     if (cancelEdits) {
         highlightedStatsRow.querySelector('.food_name').value = originalFoodValue
+        highlightedStatsRow.querySelector('.food_name').innerHTML = originalFoodValue
         originalFoodValue = null
         highlightedStatsRow.querySelector('.food_category').value = originalCategoryValue
+        highlightedStatsRow.querySelector('.food_category').innerHTML = originalCategoryValue
         originalCategoryValue = null
     }
 }
@@ -124,7 +131,7 @@ const submitEditsHandler = () => submitEdits()
 
 function highlightStatsRow(event){
     targetElement = event.target
-    if (targetElement.nodeName == "INPUT" && targetElement.classList.contains('unlocked')) {
+    if (targetElement.nodeName == "TEXTAREA" && targetElement.classList.contains('unlocked')) {
         // Totally skip this function - do not change the highlights and stats if clicking an unlocked textbox 
         return
     } else if (editMode) {
@@ -133,7 +140,7 @@ function highlightStatsRow(event){
     } else if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
         targetElement = targetElement.parentNode
-    } else if (targetElement.nodeName == "INPUT") {
+    } else if (targetElement.nodeName == "TEXTAREA") {
         targetElement = targetElement.parentNode.parentNode
     }
     if (highlightedStatsRow == targetElement) {
@@ -257,7 +264,7 @@ function highlightMergeRow(event) {
     if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
         targetElement = targetElement.parentNode
-    } else if (targetElement.nodeName == "INPUT") {
+    } else if (targetElement.nodeName == "TEXTAREA") {
         targetElement = targetElement.parentNode.parentNode
     }
     if (highlightedMergeRow == targetElement) {
@@ -306,6 +313,14 @@ function assignRowListeners() {
     rows.forEach(row => {
         row.addEventListener('click', function(event) {handleFoodRowClick(event)})
     })
+
+    let inputs = document.querySelectorAll('.food_input')
+    inputs.forEach(row => {
+        autoTextareaHeight(row)
+        row.addEventListener('change', autoTextareaHeight)
+    })
+
+    
 }
 
 assignRowListeners()

--- a/food_db/static/js/manage_food.js
+++ b/food_db/static/js/manage_food.js
@@ -5,15 +5,20 @@ let foodDataDict = getFoodData(document)
 let highlightedStatsRow
 let highlightedMergeRow
 let mergeMode = false
+let editMode = false
+let originalFoodValue = null
+let originalCategoryValue = null
 
 let foodCategoryTable = document.getElementById('foods_categories_table')
 let foodStatsHeader = document.getElementById('food_stats_header')
 let foodStatsBody = document.getElementById('food_stats_body')
 let mergeButton = document.getElementById('merge_food_button')
+let cancelMergeButton = document.getElementById('cancel_merge_food_button')
+let editButton = document.getElementById('edit_food_button')
+let cancelEditButton = document.getElementById('cancel_edit_food_button')
 
 let foodStatsMergeHeader = document.getElementById('food_stats_merge_header')
 let foodStatsMergeBody = document.getElementById('food_stats_merge_body')
-let cancelMergeButton = document.getElementById('cancel_merge_food_button')
 let badMergeTooltip = document.getElementById('cant_self_merge_tooltip')
 
 let defaultMergeHeaderText = 'Select a food to merge with'
@@ -61,13 +66,73 @@ function enterMergeMode() {
     cancelMergeButton.style.display = ''
     mergeButton = document.getElementById('merge_food_button')
     mergeButton.removeEventListener('click', enterMergeMode)
+    editButton.style.display = 'none'
 }
+
+function enterEditMode() {
+    editMode = true
+    mergeButton.style.display = 'none'
+    cancelEditButton.style.display = ''
+
+    bothInputs = highlightedStatsRow.querySelectorAll('.food_input')
+    bothInputs.forEach(input => {
+        input.classList.remove('locked')
+        input.classList.add('unlocked')
+        input.removeAttribute('readonly')
+    })
+
+    originalFoodValue = highlightedStatsRow.querySelector('.food_name').getAttribute('value')
+    originalCategoryValue = highlightedStatsRow.querySelector('.food_category').getAttribute('value')
+
+    editButton.removeEventListener('click', enterEditMode)
+    editButton.addEventListener('click', submitEditsHandler)
+    editButton.innerText = 'Save edits'
+}
+
+function resetEditMode(cancelEdits) {
+    editMode = false
+    mergeButton.style.display = ''
+    editButton.style.display = ''
+    cancelEditButton.style.display = 'none'
+
+    let allInputs = document.querySelectorAll('.food_input')
+    allInputs.forEach(input => {
+        if (input.classList.contains('unlocked')) {
+            input.classList.remove('unlocked')
+            input.classList.add('locked')
+            input.setAttribute('readonly', true)
+        }
+    })
+
+    editButton.removeEventListener('click', submitEditsHandler)
+    editButton.addEventListener('click', enterEditMode)
+    editButton.innerText = 'Edit row'
+
+    if (cancelEdits) {
+        highlightedStatsRow.querySelector('.food_name').value = originalFoodValue
+        originalFoodValue = null
+        highlightedStatsRow.querySelector('.food_category').value = originalCategoryValue
+        originalCategoryValue = null
+    }
+}
+
+async function submitEdits() {
+    return
+}
+
+const submitEditsHandler = () => submitEdits()
 
 function highlightStatsRow(event){
     targetElement = event.target
-    if (targetElement.nodeName == "TD") {
+    if (targetElement.nodeName == "INPUT" && targetElement.classList.contains('unlocked')) {
+        // Totally skip this function - do not change the highlights and stats if clicking an unlocked textbox 
+        return
+    } else if (editMode) {
+        // Also skip this function while in edit mode
+        return
+    } else if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
-        targetElement = targetElement.parentNode;   
+        targetElement = targetElement.parentNode
     } else if (targetElement.nodeName == "INPUT") {
         targetElement = targetElement.parentNode.parentNode
     }
@@ -78,6 +143,7 @@ function highlightStatsRow(event){
         foodStatsHeader.innerText = 'Select a food'
         foodStatsBody.innerHTML = ''
         mergeButton.style.display = 'none'
+        editButton.style.display = 'none'
         resetMergeMode(false, '')
     } else {
         if (highlightedStatsRow) {
@@ -95,6 +161,7 @@ function highlightStatsRow(event){
         foodStatsBody.innerHTML = foodStatsTemplate.replace('{food}',food).replace('{category}',category).replace('{recipeList}',recipeHTML)
         mergeButton.style.display = ''
         mergeButton.addEventListener('click', enterMergeMode)
+        editButton.style.display = ''
     }
 }
 
@@ -166,8 +233,11 @@ const mergeFoodsHandler = (event) => mergeFoods(event)
 function resetMergeMode(stillInMergeMode, headerText) {
     mergeMode = stillInMergeMode
     if (!stillInMergeMode) {
-        // Remove cancel button
+        // Remove cancel button and show edit button again
         cancelMergeButton.style.display = 'none'
+        if (highlightedStatsRow) {
+            editButton.style.display = ''
+        }
     }
     foodStatsMergeHeader.innerText = ''
     if (highlightedMergeRow) {
@@ -222,11 +292,8 @@ function highlightMergeRow(event) {
     }
 }
 
-function handleFoodRowClick(event, preventDefault) {
-    if (preventDefault == undefined) {
-        // when this is called from handleTextInputClick, we don't need to (and can't) preventDefault again
-        event.preventDefault()
-    } 
+function handleFoodRowClick(event) {
+    event.preventDefault()
     if (mergeMode == true) {
         highlightMergeRow(event)
     } else {
@@ -243,3 +310,4 @@ function assignRowListeners() {
 
 assignRowListeners()
 $(document).ready(showHideTabs)
+editButton.addEventListener('click', enterEditMode)

--- a/food_db/static/js/manage_food.js
+++ b/food_db/static/js/manage_food.js
@@ -79,15 +79,18 @@ function enterEditMode() {
     mergeButton.style.display = 'none'
     cancelEditButton.style.display = ''
 
-    bothInputs = highlightedStatsRow.querySelectorAll('.food_input')
-    bothInputs.forEach(input => {
-        input.classList.remove('locked')
-        input.classList.add('unlocked')
-        input.removeAttribute('readonly')
-    })
+    let nameInput = highlightedStatsRow.querySelector('.food_name')
+    nameInput.classList.remove('locked')
+    nameInput.classList.add('unlocked')
+    nameInput.removeAttribute('readonly')
 
-    originalFoodValue = highlightedStatsRow.querySelector('.food_name').value
-    originalCategoryValue = highlightedStatsRow.querySelector('.food_category').value
+    let categoryLabel = highlightedStatsRow.querySelector('.food_category_label')
+    let categorySelect = highlightedStatsRow.querySelector('.food_category')
+    categoryLabel.style.display = 'none'
+    categorySelect.style.display = ''
+
+    originalFoodValue = nameInput.value
+    originalCategoryValue = categoryLabel.innerText
 
     editButton.removeEventListener('click', enterEditMode)
     editButton.addEventListener('click', submitEditsHandler)
@@ -100,14 +103,17 @@ function resetEditMode(cancelEdits) {
     editButton.style.display = ''
     cancelEditButton.style.display = 'none'
 
-    let allInputs = document.querySelectorAll('.food_input')
-    allInputs.forEach(input => {
-        if (input.classList.contains('unlocked')) {
-            input.classList.remove('unlocked')
-            input.classList.add('locked')
-            input.setAttribute('readonly', true)
-        }
-    })
+    let nameInput = highlightedStatsRow.querySelector('.food_name')
+    if (nameInput.classList.contains('unlocked')) {
+        nameInput.classList.remove('unlocked')
+        nameInput.classList.add('locked')
+        nameInput.setAttribute('readonly', true)
+    }
+
+    let categoryLabel = highlightedStatsRow.querySelector('.food_category_label')
+    let categorySelect = highlightedStatsRow.querySelector('.food_category')
+    categoryLabel.style.display = ''
+    categorySelect.style.display = 'none'
 
     editButton.removeEventListener('click', submitEditsHandler)
     editButton.addEventListener('click', enterEditMode)
@@ -117,8 +123,8 @@ function resetEditMode(cancelEdits) {
         highlightedStatsRow.querySelector('.food_name').value = originalFoodValue
         highlightedStatsRow.querySelector('.food_name').innerHTML = originalFoodValue
         originalFoodValue = null
-        highlightedStatsRow.querySelector('.food_category').value = originalCategoryValue
-        highlightedStatsRow.querySelector('.food_category').innerHTML = originalCategoryValue
+
+        // no need to change any values for the Category since categoryLabel still holds the original value
         originalCategoryValue = null
     }
 }
@@ -131,8 +137,9 @@ const submitEditsHandler = () => submitEdits()
 
 function highlightStatsRow(event){
     targetElement = event.target
-    if (targetElement.nodeName == "TEXTAREA" && targetElement.classList.contains('unlocked')) {
-        // Totally skip this function - do not change the highlights and stats if clicking an unlocked textbox 
+    let inputNodeNames = ['TEXTAREA', 'SELECT', 'SPAN']
+    if (inputNodeNames.includes(targetElement.nodeName) && targetElement.classList.contains('unlocked')) {
+        // Totally skip this function - do not change the highlights and stats if clicking an unlocked input 
         return
     } else if (editMode) {
         // Also skip this function while in edit mode
@@ -140,7 +147,7 @@ function highlightStatsRow(event){
     } else if (targetElement.nodeName == "TD") {
         // Target the parent row so we can standardize the code below
         targetElement = targetElement.parentNode
-    } else if (targetElement.nodeName == "TEXTAREA") {
+    } else if (inputNodeNames.includes(targetElement.nodeName)) {
         targetElement = targetElement.parentNode.parentNode
     }
     if (highlightedStatsRow == targetElement) {
@@ -314,7 +321,7 @@ function assignRowListeners() {
         row.addEventListener('click', function(event) {handleFoodRowClick(event)})
     })
 
-    let inputs = document.querySelectorAll('.food_input')
+    let inputs = document.querySelectorAll('.food_name')
     inputs.forEach(row => {
         autoTextareaHeight(row)
         row.addEventListener('change', autoTextareaHeight)


### PR DESCRIPTION
Title pretty much says it all. I converted the `inputs` to `textarea` for food name and `select` for food category. I made sure to maintain the lack of borders and inability to interact with the text until you enter edit mode. Added edit and cancel edit buttons and a new API for editing.