### PR TITLE
Create MD syntax that enables ingredient name tooltips

### DIFF
--- a/food_db/food_db_app/templates/add_edit_recipe.html
+++ b/food_db/food_db_app/templates/add_edit_recipe.html
@@ -272,14 +272,26 @@
     </h2>
     <span id="markdown_help_tooltip" class="tooltip help_tooltip">
         You can format the text of your recipe steps using Markdown syntax. You can google the full set of rules, but here are some of the most common tricks:<br><br>
-        <p id="markdown_help_indented_text">• **Double asterisks** make text <b>bold</b><br>
-        • *Single asterisks* or _underscores_ make it <i>italic</i>.<br>
-        • Use hyphens or asterisks to create bullet points<br>
-        • Make headings by starting a line with 1-4 hash symbols (#), like this:<br><br>
-        </p><p id="markdown_help_centered_text">
-        # This is a large header<br>
-        #### This is a small one<br>
-        This is the normal text</p>
+        <p class="markdown_help_indented_text">
+            • **Double asterisks** make text <b>bold</b><br>
+            • *Single asterisks* or _underscores_ make it <i>italic</i>.<br>
+            • Use hyphens or asterisks to create bullet points<br>
+            • Make headings by starting a line with 1-4 hash symbols (#), like this:<br><br>
+        </p>
+        <p class="markdown_help_centered_text">
+            # This is a large header<br>
+            #### This is a small one<br>
+            This is the normal text<br><br>
+        </p>
+        There is also a custom syntax that you can use to create tooltips over your text that link back to ingredients. There are long and short forms of the syntax:<br><br>
+        <p class="markdown_help_centered_text">
+            This short form is the easiest and can be used when you're fine with the visible hyperlink text being the same as the food name:<br>
+            [ingredient food name]<br><br>
+            This medium form is the same as above, but lets you set a different visible text than the food's name:<br>
+            [visible hyperlink text](!ingredient food name)<br><br>
+            This longest form is only necessary when the same food is used in multiple different ingredient categories and you need to specify one:<br>
+            [visible hyperlink text](!ingredient food name;ingredient category name)<br><br>
+        </p>
     </span>
     {{create_recipe_form.extra_step_count}}
     <table id="step_table" class="form-table">

--- a/food_db/food_db_app/templates/recipe_detail.html
+++ b/food_db/food_db_app/templates/recipe_detail.html
@@ -200,7 +200,7 @@
                         <input type="checkbox" class="cooking-checkbox step-checkbox" data-step-id="{{ step.order_number }}">
                     </td>
                     <td class="step_description_text">
-                        {{ step.description | markdown | safe }}
+                        {{ step.description | markdown:recipe.title | safe }}
                     </td>
                 </tr>
             {% endfor %}

--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -8,54 +8,54 @@ register = template.Library()
 
 @register.filter()
 @stringfilter
-def markdown(value):
+def markdown(value, recipe_title):
     # Process custom ingredient links before passing to markdown
-    processed_value = _process_ingredient_links(value)
+    processed_value = _process_ingredient_links(value, recipe_title)
     return md.markdown(processed_value, extensions=['markdown.extensions.fenced_code'])
 
-def _process_ingredient_links(text):
+def _process_ingredient_links(text, recipe_title):
     """
-    Process custom ingredient links in the format [text](!ingredient_id)
+    Process custom ingredient links in the format [text](!ingredient_name;ingredient_category)
     and replace them with HTML spans that include tooltip data.
     """
-    # Pattern to match [text](!ingredient_id)
-    pattern = r'\[([^\]]+)\]\(!(\d+)\)'
+    # Pattern to match [text](!ingredient_name) or [text](!ingredient_name;ingredient_category)
+    pattern = r'\[([^\]]+)\]\(!([\w ]+)(;[\w ]+)?\)'
     
     def replace_ingredient_link(match):
         link_text = match.group(1)
-        ingredient_id = match.group(2)
+        ingredient_name = match.group(2)
+        ingredient_category = match.group(3)  # None if not specified
         
         try:
             # Import here to avoid circular imports
-            from .models import Ingredient
+            from food_db_app.models import Ingredient
+            from food_db_app.views import RecipeIngredientData
             
-            ingredient = Ingredient.objects.select_related('food', 'unit_of_measurement').get(id=ingredient_id)
+            # We don't want to require the specification of ingredient_category, even if the ingredient does have a category. So try to find it first without filtering on category.
+            try:
+                ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name)
+            except Ingredient.MultipleObjectsReturned:
+                ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name, ingredient_category__name=ingredient_category or '')
+                
+            quantity = RecipeIngredientData.stringify_ingredient_quantity(ingredient.quantity, ingredient.unit_of_measurement.name or '', 1)  # FIXME: gotta work dynamically with the multiplier, right now it's set to 1
             
-            # Build tooltip content
-            tooltip_parts = []
-            if ingredient.food:
-                tooltip_parts.append(ingredient.food.name)
+            tooltip_content = f'{quantity} {ingredient.food.name}'
             
-            if ingredient.quantity and ingredient.unit_of_measurement:
-                tooltip_parts.append(f"{ingredient.quantity} {ingredient.unit_of_measurement.name}")
-            elif ingredient.quantity:
-                tooltip_parts.append(str(ingredient.quantity))
-            elif ingredient.unit_of_measurement:
-                tooltip_parts.append(ingredient.unit_of_measurement.name)
+            if ingredient.quantity != 1 and not ingredient.unit_of_measurement and not ingredient.food.name.endswith('s'):
+                tooltip_content += 's'
             
             if ingredient.notes:
-                tooltip_parts.append(ingredient.notes)
-            
-            tooltip_content = " - ".join(tooltip_parts)
+                tooltip_content += f' - {ingredient.notes}'
             
             # Return HTML span with tooltip attributes
-            return f'<span class="ingredient-link" data-tooltip="{tooltip_content}">{link_text}</span>'
+            return f'<span class="ingredient_link" data-tooltip="{tooltip_content}">{link_text}</span>'
             
         except Ingredient.DoesNotExist:
-            # If ingredient doesn't exist, return the original text
-            return match.group(0)
+            # If ingredient doesn't exist, return the hyperlink text (without the link formatting around it) plus an error
+            return match.group(1) + ' <linked ingredient not found>'
+        except Ingredient.MultipleObjectsReturned:
+            return match.group(1) + ' <multiple linked ingredients found; try specifying category>'
         except Exception:
-            # If any other error occurs, return the original text
-            return match.group(0)
+            return match.group(1) + ' <link error>'
     
     return re.sub(pattern, replace_ingredient_link, text)

--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -1,5 +1,6 @@
 from django import template
 from django.template.defaultfilters import stringfilter
+import re
 
 import markdown as md
 
@@ -8,4 +9,53 @@ register = template.Library()
 @register.filter()
 @stringfilter
 def markdown(value):
-    return md.markdown(value, extensions=['markdown.extensions.fenced_code'])
+    # Process custom ingredient links before passing to markdown
+    processed_value = _process_ingredient_links(value)
+    return md.markdown(processed_value, extensions=['markdown.extensions.fenced_code'])
+
+def _process_ingredient_links(text):
+    """
+    Process custom ingredient links in the format [text](!ingredient_id)
+    and replace them with HTML spans that include tooltip data.
+    """
+    # Pattern to match [text](!ingredient_id)
+    pattern = r'\[([^\]]+)\]\(!(\d+)\)'
+    
+    def replace_ingredient_link(match):
+        link_text = match.group(1)
+        ingredient_id = match.group(2)
+        
+        try:
+            # Import here to avoid circular imports
+            from .models import Ingredient
+            
+            ingredient = Ingredient.objects.select_related('food', 'unit_of_measurement').get(id=ingredient_id)
+            
+            # Build tooltip content
+            tooltip_parts = []
+            if ingredient.food:
+                tooltip_parts.append(ingredient.food.name)
+            
+            if ingredient.quantity and ingredient.unit_of_measurement:
+                tooltip_parts.append(f"{ingredient.quantity} {ingredient.unit_of_measurement.name}")
+            elif ingredient.quantity:
+                tooltip_parts.append(str(ingredient.quantity))
+            elif ingredient.unit_of_measurement:
+                tooltip_parts.append(ingredient.unit_of_measurement.name)
+            
+            if ingredient.notes:
+                tooltip_parts.append(ingredient.notes)
+            
+            tooltip_content = " - ".join(tooltip_parts)
+            
+            # Return HTML span with tooltip attributes
+            return f'<span class="ingredient-link" data-tooltip="{tooltip_content}">{link_text}</span>'
+            
+        except Ingredient.DoesNotExist:
+            # If ingredient doesn't exist, return the original text
+            return match.group(0)
+        except Exception:
+            # If any other error occurs, return the original text
+            return match.group(0)
+    
+    return re.sub(pattern, replace_ingredient_link, text)

--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -15,27 +15,38 @@ def markdown(value, recipe_title):
 
 def _process_ingredient_links(text, recipe_title):
     """
-    Process custom ingredient links in the format [text](!ingredient_name;ingredient_category)
+    Process custom ingredient links in the format [text](!ingredient name;ingredient category)
     and replace them with HTML spans that include tooltip data.
     """
-    # Pattern to match [text](!ingredient_name) or [text](!ingredient_name;ingredient_category)
-    pattern = r'\[([^\]]+)\]\(!([\w ]+)(;[\w ]+)?\)'
+    # Pattern to match [ingredient name] or [text](!ingredient name) or [text](!ingredient name;ingredient category)
+    pattern = r'\[([^\]]+)\](\(!([\w ]+)(;[\w ]+)?\))?'
     
     def replace_ingredient_link(match):
         link_text = match.group(1)
-        ingredient_name = match.group(2)
-        ingredient_category = match.group(3)  # None if not specified
+        # The following may be None
+        parentheses_clause = match.group(2)
+        ingredient_name = match.group(3)
+        ingredient_category = match.group(4)
         
         try:
             # Import here to avoid circular imports
             from food_db_app.models import Ingredient
             from food_db_app.views import RecipeIngredientData
-            
-            # We don't want to require the specification of ingredient_category, even if the ingredient does have a category. So try to find it first without filtering on category.
-            try:
-                ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name)
-            except Ingredient.MultipleObjectsReturned:
-                ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name, ingredient_category__name=ingredient_category or '')
+
+            # First case is the ingredient name written just in brackets, like [ingredient name]
+            if not parentheses_clause:
+                ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=link_text)
+            else:
+                # In this case, both brackets and parenetheses were used
+                # Checking the second case: [visible text](!ingredient name)
+                # We don't want to require the specification of ingredient_category, even if the ingredient does have a category. So try to find it first without filtering on category.
+                try:
+                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name)
+                except Ingredient.MultipleObjectsReturned:
+                    # The same food was used for multiple ingredients in this recipe, so an ingredient category is required. The full syntax for specifying this is [visible text](!ingredient name;category name)
+                    cat = ingredient_category or ''  # if no category was specified, try searching with a blank string (which is what happens when no category is attached to the ingredient)
+                    cat = cat.replace(';','').strip()  # if a category was specified, remove leading whitespace and the semicolon from the regular expression match
+                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name, ingredient_category__name=cat)
                 
             quantity = RecipeIngredientData.stringify_ingredient_quantity(ingredient.quantity, ingredient.unit_of_measurement.name or '', 1)  # FIXME: gotta work dynamically with the multiplier, right now it's set to 1
             

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -701,10 +701,10 @@ button.merge_selected {
     opacity: 100%;
     z-index: 1000;
 }
-#markdown_help_indented_text {
+.markdown_help_indented_text {
     margin-left: 1rem;
 }
-#markdown_help_centered_text {
+.markdown_help_centered_text {
     text-align: center;
 }
 #confetti-canvas {

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -291,6 +291,15 @@ textarea.default_text {
     transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, color 0.2s ease-in-out;
     transition: opacity 0.8s;
 }
+.ingredient_link_tooltip {
+    background: #3cc382;
+    color: white;
+    position: absolute;
+    padding: 5px;
+    font-size: smaller;
+    transition: opacity 0.8s;
+}
+
 /* When screen is at least 600 px wide */
 @media screen and (min-width: 600px) {
     .cooking_mode_tooltip {
@@ -916,54 +925,14 @@ details[open] summary {
 }
 
 /* Ingredient links styling */
-.ingredient-link {
-    color: #0066cc;
+.ingredient_link {
     text-decoration: underline;
     cursor: pointer;
     position: relative;
 }
 
-.ingredient-link:hover {
-    color: #004499;
-    text-decoration: underline;
-}
-
-/* Ingredient tooltip styling */
-.ingredient-tooltip {
-    position: absolute;
-    background: #333;
-    color: white;
-    padding: 8px 12px;
-    border-radius: 6px;
-    font-size: 0.9rem;
-    max-width: 300px;
-    z-index: 1000;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    pointer-events: none;
-    white-space: nowrap;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-}
-
-.ingredient-tooltip.visible {
-    opacity: 1;
-}
-
-.ingredient-tooltip::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: #333 transparent transparent transparent;
-}
-
-/* Arrow pointing up when tooltip appears below */
-.ingredient-tooltip[style*="--arrow-direction: up"]::after {
-    top: -10px;
-    border-color: transparent transparent #333 transparent;
+.ingredient_link:hover {
+    color: #47D3E5;
 }
 
 .cooking-mode-active tr:has(td.checked-ingredient):not(.ingredient_category_row),

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -915,6 +915,57 @@ details[open] summary {
     display: none;
 }
 
+/* Ingredient links styling */
+.ingredient-link {
+    color: #0066cc;
+    text-decoration: underline;
+    cursor: pointer;
+    position: relative;
+}
+
+.ingredient-link:hover {
+    color: #004499;
+    text-decoration: underline;
+}
+
+/* Ingredient tooltip styling */
+.ingredient-tooltip {
+    position: absolute;
+    background: #333;
+    color: white;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    max-width: 300px;
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.ingredient-tooltip.visible {
+    opacity: 1;
+}
+
+.ingredient-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #333 transparent transparent transparent;
+}
+
+/* Arrow pointing up when tooltip appears below */
+.ingredient-tooltip[style*="--arrow-direction: up"]::after {
+    top: -10px;
+    border-color: transparent transparent #333 transparent;
+}
+
 .cooking-mode-active tr:has(td.checked-ingredient):not(.ingredient_category_row),
 .cooking-mode-active tr.ingredient_category_row:has(td.checked-ingredient) td:not(:first-child),
 .cooking-mode-active .checked-ingredient,

--- a/food_db/static/js/tooltip.js
+++ b/food_db/static/js/tooltip.js
@@ -1,3 +1,5 @@
+let ingredientLinks = document.querySelectorAll('.ingredient_link');
+
 function hideToolTip(tooltip) {
     tooltip.classList.remove('visible')
 }
@@ -15,58 +17,37 @@ function showAndHideTooltip(tooltip, duration) {
     setTimeout(hideToolTip, duration, tooltip)
 }
 
-// Ingredient link tooltip functionality
-document.addEventListener('DOMContentLoaded', function() {
-    // Find all ingredient links
-    let ingredientLinks = document.querySelectorAll('.ingredient-link');
+ingredientLinks.forEach(function(link) {
+    let tooltip = null;
     
-    ingredientLinks.forEach(function(link) {
-        let tooltip = null;
-        
-        // Create tooltip element
-        function createTooltip() {
-            let tooltipElement = document.createElement('div');
-            tooltipElement.className = 'ingredient-tooltip';
-            tooltipElement.textContent = link.getAttribute('data-tooltip');
-            document.body.appendChild(tooltipElement);
-            return tooltipElement;
+    // Create tooltip element
+    function createTooltip() {
+        let tooltipElement = document.createElement('div');
+        tooltipElement.classList.add('ingredient_link_tooltip');
+        tooltipElement.classList.add('tooltip');
+
+        // Each ingredient_link span has the tooltip content already embedded in data-tooltip
+        tooltipElement.textContent = link.getAttribute('data-tooltip');
+        document.body.appendChild(tooltipElement);
+        return tooltipElement;
+    }
+    
+    // Show tooltip when hovering over ingredient_link
+    link.addEventListener('mouseenter', function(e) {
+        if (!tooltip) {
+            tooltip = createTooltip();
         }
+
+        tooltip.style.left = `${link.offsetLeft - 5}px`;
+        tooltip.style.top = `${link.offsetTop - 40}px`;
         
-        // Show tooltip on mouseenter
-        link.addEventListener('mouseenter', function(e) {
-            if (!tooltip) {
-                tooltip = createTooltip();
-            }
-            
-            // Position tooltip
-            let rect = link.getBoundingClientRect();
-            let tooltipRect = tooltip.getBoundingClientRect();
-            
-            let left = rect.left + (rect.width / 2) - (tooltipRect.width / 2);
-            let top = rect.top - tooltipRect.height - 10;
-            
-            // Adjust if tooltip would go off screen
-            if (left < 10) left = 10;
-            if (left + tooltipRect.width > window.innerWidth - 10) {
-                left = window.innerWidth - tooltipRect.width - 10;
-            }
-            if (top < 10) {
-                top = rect.bottom + 10;
-                // Change arrow direction
-                tooltip.style.setProperty('--arrow-direction', 'up');
-            }
-            
-            tooltip.style.left = left + 'px';
-            tooltip.style.top = top + 'px';
-            
-            showToolTip(tooltip);
-        });
-        
-        // Hide tooltip on mouseleave
-        link.addEventListener('mouseleave', function() {
-            if (tooltip) {
-                hideToolTip(tooltip);
-            }
-        });
+        showToolTip(tooltip);
+    });
+    
+    // Hide tooltip on mouseleave
+    link.addEventListener('mouseleave', function() {
+        if (tooltip) {
+            hideToolTip(tooltip);
+        }
     });
 });

--- a/food_db/static/js/tooltip.js
+++ b/food_db/static/js/tooltip.js
@@ -14,3 +14,59 @@ function showAndHideTooltip(tooltip, duration) {
     setTimeout(showToolTip, 300, tooltip)
     setTimeout(hideToolTip, duration, tooltip)
 }
+
+// Ingredient link tooltip functionality
+document.addEventListener('DOMContentLoaded', function() {
+    // Find all ingredient links
+    let ingredientLinks = document.querySelectorAll('.ingredient-link');
+    
+    ingredientLinks.forEach(function(link) {
+        let tooltip = null;
+        
+        // Create tooltip element
+        function createTooltip() {
+            let tooltipElement = document.createElement('div');
+            tooltipElement.className = 'ingredient-tooltip';
+            tooltipElement.textContent = link.getAttribute('data-tooltip');
+            document.body.appendChild(tooltipElement);
+            return tooltipElement;
+        }
+        
+        // Show tooltip on mouseenter
+        link.addEventListener('mouseenter', function(e) {
+            if (!tooltip) {
+                tooltip = createTooltip();
+            }
+            
+            // Position tooltip
+            let rect = link.getBoundingClientRect();
+            let tooltipRect = tooltip.getBoundingClientRect();
+            
+            let left = rect.left + (rect.width / 2) - (tooltipRect.width / 2);
+            let top = rect.top - tooltipRect.height - 10;
+            
+            // Adjust if tooltip would go off screen
+            if (left < 10) left = 10;
+            if (left + tooltipRect.width > window.innerWidth - 10) {
+                left = window.innerWidth - tooltipRect.width - 10;
+            }
+            if (top < 10) {
+                top = rect.bottom + 10;
+                // Change arrow direction
+                tooltip.style.setProperty('--arrow-direction', 'up');
+            }
+            
+            tooltip.style.left = left + 'px';
+            tooltip.style.top = top + 'px';
+            
+            showToolTip(tooltip);
+        });
+        
+        // Hide tooltip on mouseleave
+        link.addEventListener('mouseleave', function() {
+            if (tooltip) {
+                hideToolTip(tooltip);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Modifies markdown templatetag so we use a custom markdown-like syntax to create a "hyperlink" that, instead of opening a new URL, opens a tooltip that contains an ingredient's full info (food, quantity, notes).

This is part of #79.