### PR TITLE
Automatically create ingredient links when adding a new recipe

### DIFF
--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -13,16 +13,10 @@ def markdown(value, recipe_title):
     processed_value = process_ingredient_links(value, recipe_title)
     return md.markdown(processed_value, extensions=['markdown.extensions.fenced_code'])
 
-def process_ingredient_links(text, recipe_title, auto_parse=False):
+def process_ingredient_links(text, recipe_title):
     """
     Process custom ingredient links in the format [text](!ingredient name;ingredient category)
     and replace them with HTML spans that include tooltip data.
-
-    When submitting a recipe, this function is triggered automatically, and in that case auto_parse
-    is True. In this scenario, any text in the step description that matches an ingredient name is
-    automatically wrapped in [square brackets]. The text then goes through this function, attempting to
-    establish links back to ingredients. Errors will be ignored, and the original text (before the
-    square brackets were added) will be returned.  
     """
     # Pattern to match [ingredient name] or [text](!ingredient name) or [text](!ingredient name;ingredient category)
     pattern = r'\[([^\]]+)\](\(!([\w ]+)(;[\w ]+)?\))?'
@@ -47,12 +41,12 @@ def process_ingredient_links(text, recipe_title, auto_parse=False):
                 # Checking the second case: [visible text](!ingredient name)
                 # We don't want to require the specification of ingredient_category, even if the ingredient does have a category. So try to find it first without filtering on category.
                 try:
-                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name)
+                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name__iexact=ingredient_name)
                 except Ingredient.MultipleObjectsReturned:
                     # The same food was used for multiple ingredients in this recipe, so an ingredient category is required. The full syntax for specifying this is [visible text](!ingredient name;category name)
                     cat = ingredient_category or ''  # if no category was specified, try searching with a blank string (which is what happens when no category is attached to the ingredient)
                     cat = cat.replace(';','').strip()  # if a category was specified, remove leading whitespace and the semicolon from the regular expression match
-                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name=ingredient_name, ingredient_category__name=cat)
+                    ingredient = Ingredient.objects.get(recipe__title=recipe_title, food__name__iexact=ingredient_name, ingredient_category__name__iexact=cat)
                 
             quantity = RecipeIngredientData.stringify_ingredient_quantity(ingredient.quantity, ingredient.unit_of_measurement.name or '', 1)  # FIXME: gotta work dynamically with the multiplier, right now it's set to 1
             
@@ -68,8 +62,6 @@ def process_ingredient_links(text, recipe_title, auto_parse=False):
             return f'<span class="ingredient_link" data-tooltip="{tooltip_content}">{link_text}</span>'
             
         except Exception as e:
-            if auto_parse == True:
-                return match.group(1)
             if isinstance(e, Ingredient.DoesNotExist):
                 error_message = ' <linked ingredient not found>'
             elif isinstance(e, Ingredient.MultipleObjectsReturned):
@@ -78,4 +70,4 @@ def process_ingredient_links(text, recipe_title, auto_parse=False):
                 error_message = ' <link error>'
             return match.group(1) + error_message
     
-    return re.sub(pattern, replace_ingredient_link, text)
+    return re.sub(pattern, replace_ingredient_link, text, flags=re.IGNORECASE)

--- a/food_db/food_db_app/templatetags/markdown.py
+++ b/food_db/food_db_app/templatetags/markdown.py
@@ -10,13 +10,19 @@ register = template.Library()
 @stringfilter
 def markdown(value, recipe_title):
     # Process custom ingredient links before passing to markdown
-    processed_value = _process_ingredient_links(value, recipe_title)
+    processed_value = process_ingredient_links(value, recipe_title)
     return md.markdown(processed_value, extensions=['markdown.extensions.fenced_code'])
 
-def _process_ingredient_links(text, recipe_title):
+def process_ingredient_links(text, recipe_title, auto_parse=False):
     """
     Process custom ingredient links in the format [text](!ingredient name;ingredient category)
     and replace them with HTML spans that include tooltip data.
+
+    When submitting a recipe, this function is triggered automatically, and in that case auto_parse
+    is True. In this scenario, any text in the step description that matches an ingredient name is
+    automatically wrapped in [square brackets]. The text then goes through this function, attempting to
+    establish links back to ingredients. Errors will be ignored, and the original text (before the
+    square brackets were added) will be returned.  
     """
     # Pattern to match [ingredient name] or [text](!ingredient name) or [text](!ingredient name;ingredient category)
     pattern = r'\[([^\]]+)\](\(!([\w ]+)(;[\w ]+)?\))?'
@@ -61,12 +67,15 @@ def _process_ingredient_links(text, recipe_title):
             # Return HTML span with tooltip attributes
             return f'<span class="ingredient_link" data-tooltip="{tooltip_content}">{link_text}</span>'
             
-        except Ingredient.DoesNotExist:
-            # If ingredient doesn't exist, return the hyperlink text (without the link formatting around it) plus an error
-            return match.group(1) + ' <linked ingredient not found>'
-        except Ingredient.MultipleObjectsReturned:
-            return match.group(1) + ' <multiple linked ingredients found; try specifying category>'
-        except Exception:
-            return match.group(1) + ' <link error>'
+        except Exception as e:
+            if auto_parse == True:
+                return match.group(1)
+            if isinstance(e, Ingredient.DoesNotExist):
+                error_message = ' <linked ingredient not found>'
+            elif isinstance(e, Ingredient.MultipleObjectsReturned):
+                error_message = ' <multiple linked ingredients found; try specifying category>'
+            else:
+                error_message = ' <link error>'
+            return match.group(1) + error_message
     
     return re.sub(pattern, replace_ingredient_link, text)

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -2,7 +2,7 @@ import json
 import re
 import requests
 
-from collections import defaultdict, OrderedDict
+from collections import Counter, defaultdict, OrderedDict
 from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal
@@ -502,16 +502,30 @@ def add_recipe(request):
                     ingredient_instances.append(ingredient_instance)
                 
                 Ingredient.objects.bulk_create(ingredient_instances)
+            
+            # Gather food names and sort them by number of words (descending), then by total string length (descending). The sort order helps ensure that something like "rice vinegar" will match correctly before it matches to "rice".
+            food_set = [ingred.food.name for ingred in ingredient_instances if Counter(ingredient_instances)[ingred] == 1]  # only returns foods that are not duplicated - any food mentioned more than once in the ingredient list will not be included at all
+            sorted_food_list = sorted(
+                food_set,
+                key=lambda name: (len(name.split()), len(name)),
+                reverse=True
+            )
+            food_name_regex = '(' + '|'.join(sorted_food_list) + ')'
 
             if create_recipe_form.cleaned_data['step_0_description'] != '':  # steps were entered for this recipe
                 # Now, for each step
                 step_ids = {re.search(r'step_(\d+)', input_name).group() for input_name in create_recipe_form.cleaned_data.keys() if input_name.startswith('step_')}  # Creates a distinct set of step ID prefixes, e.g. {step_0, step_1}
                 for i, step_id_prefix in enumerate(sorted(step_ids)):
                     step_description = create_recipe_form.cleaned_data[f'{step_id_prefix}_description']
+                    # Attempt to automatically find ingredient links. This involves searching the step description for ingredient names, then wrapping the names with [square brackets].
+                    # This is only done when adding a recipe - not on edit - to prevent driving the user crazy with repeated attempts at the wrong ingredient links
+                    def wrap_food_with_brackets(match):
+                        return '[' + match + ']'
+                    step_description_with_links = re.sub(food_name_regex, wrap_food_with_brackets, step_description, flags=re.IGNORECASE)
                     step_instance = RecipeStep(
                         recipe=recipe_instance,
                         order_number=i + 1,
-                        description=step_description,
+                        description=step_description_with_links,
                     )
                     step_instances.append(step_instance)
                 


### PR DESCRIPTION
To be minimal, it only attempts links that have exact matches in the ingredient name list, and avoids any foods that are used for multiple ingredients (because that would require then specifying the category name).

This is just a first pass, which will hopefully tempt users into more completely - but manually - setting up all the links.

Part of #79