### PR TITLE
Create Bulk Prep page and cart mechanism

### DIFF
--- a/food_db/food_db_app/templates/bulk_prep.html
+++ b/food_db/food_db_app/templates/bulk_prep.html
@@ -6,9 +6,6 @@
 {{ tags|json_script:"tagResultsRaw" }}
 
 <div id="cart_contents">
-    {% with result_count=text_search.qs|length %}
-    <h2>{% if result_count == 0 %}Ah shit, no matching recipes found 😔{% else %}Found {{ result_count }} {% if is_baking_recipe == 'true' %}baking{% else %}cooking{% endif %} recipe{% endif %}{% if result_count > 1 %}s{% endif %}</h2>
-    {% endwith %}
     <table id="search_results_table">
         <thead>
             <th>
@@ -43,11 +40,11 @@
             </th>
         </thead>
         <tbody>
-            {% for recipe, data in recipe_data.items %}
+            {% for recipe in recipes %}
             <tr>
                 <td>
-                    <p class="search_result"><a class="left_side_of_page" href="{% url 'recipe_detail' data.clean_key %}">{{ recipe }}</a>
-                        {% for tag in data.tags %}
+                    <p class="search_result"><a class="left_side_of_page" href="{% url 'recipe_detail' recipe.clean_key %}">{{ recipe }}</a>
+                        {% for tag in recipe.associated_tags %}
                             <span 
                                 class="tag_display_label small"
                                 style="background-color: {{ tag.fill_color }}; color: {{ tag.text_color }}; {% if tag.has_border %}outline: 2px solid {{ tag.border_color }};{% endif %}"
@@ -55,16 +52,7 @@
                         {% endfor %}<br /></p>
                 </td>
                 <td value="{{ data.duration_minutes }}">
-                    {{ data.duration_string }}
-                </td>
-                <td>
-                    {{ data.times_cooked }}
-                </td>
-                <td>
-                    {{ data.last_cooked }}
-                </td>
-                <td>
-                    {{ data.date_created }}
+                    {{ recipe.duration_minutes }}
                 </td>
             </tr>
             {% endfor %}

--- a/food_db/food_db_app/templates/bulk_prep.html
+++ b/food_db/food_db_app/templates/bulk_prep.html
@@ -1,0 +1,75 @@
+{% extends 'main.html' %}
+{% load static %}
+{% block content %}
+
+{{ recipe_data|json_script:"searchResultsRaw" }}
+{{ tags|json_script:"tagResultsRaw" }}
+
+<div id="cart_contents">
+    {% with result_count=text_search.qs|length %}
+    <h2>{% if result_count == 0 %}Ah shit, no matching recipes found 😔{% else %}Found {{ result_count }} {% if is_baking_recipe == 'true' %}baking{% else %}cooking{% endif %} recipe{% endif %}{% if result_count > 1 %}s{% endif %}</h2>
+    {% endwith %}
+    <table id="search_results_table">
+        <thead>
+            <th>
+                <a>Recipe</a>
+                <!-- These two different <i> elements are the before and after click icons. They get swapped in toggleSortIcon(). -->
+                <i id="recipe_asc_icon" class="fa fa-caret-down search_sort_icon"></i>
+                <i id="recipe_desc_icon" class="fa fa-caret-up search_sort_icon"></i>
+            </th>
+            <th>
+                <a>Duration</a>
+                <!-- These two different <i> elements are the before and after click icons. They get swapped in toggleSortIcon(). -->
+                <i id="duration_asc_icon" class="fa fa-caret-down search_sort_icon"></i>
+                <i id="duration_desc_icon" class="fa fa-caret-up search_sort_icon"></i>
+            </th>
+            <th>
+                <a>Times cooked</a>
+                <!-- These two different <i> elements are the before and after click icons. They get swapped in toggleSortIcon(). -->
+                <i id="times_cooked_asc_icon" class="fa fa-caret-down search_sort_icon"></i>
+                <i id="times_cooked_desc_icon" class="fa fa-caret-up search_sort_icon"></i>
+            </th>
+            <th>
+                <a>Last cooked</a>
+                <!-- These two different <i> elements are the before and after click icons. They get swapped in toggleSortIcon(). -->
+                <i id="last_cooked_asc_icon" class="fa fa-caret-down search_sort_icon"></i>
+                <i id="last_cooked_desc_icon" class="fa fa-caret-up search_sort_icon"></i>
+            </th>
+            <th>
+                <a>Recipe created</a>
+                <!-- These two different <i> elements are the before and after click icons. They get swapped in toggleSortIcon(). -->
+                <i id="date_created_asc_icon" class="fa fa-caret-down search_sort_icon"></i>
+                <i id="date_created_desc_icon" class="fa fa-caret-up search_sort_icon"></i>
+            </th>
+        </thead>
+        <tbody>
+            {% for recipe, data in recipe_data.items %}
+            <tr>
+                <td>
+                    <p class="search_result"><a class="left_side_of_page" href="{% url 'recipe_detail' data.clean_key %}">{{ recipe }}</a>
+                        {% for tag in data.tags %}
+                            <span 
+                                class="tag_display_label small"
+                                style="background-color: {{ tag.fill_color }}; color: {{ tag.text_color }}; {% if tag.has_border %}outline: 2px solid {{ tag.border_color }};{% endif %}"
+                            >{{ tag.name }}</span>
+                        {% endfor %}<br /></p>
+                </td>
+                <td value="{{ data.duration_minutes }}">
+                    {{ data.duration_string }}
+                </td>
+                <td>
+                    {{ data.times_cooked }}
+                </td>
+                <td>
+                    {{ data.last_cooked }}
+                </td>
+                <td>
+                    {{ data.date_created }}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock content %}

--- a/food_db/food_db_app/templates/bulk_prep.html
+++ b/food_db/food_db_app/templates/bulk_prep.html
@@ -51,8 +51,11 @@
                             >{{ tag.name }}</span>
                         {% endfor %}<br /></p>
                 </td>
-                <td value="{{ data.duration_minutes }}">
+                <td value="{{ recipe.duration_minutes }}">
                     {{ recipe.duration_minutes }}
+                </td>
+                <td style="background-color: white !important;">
+                    <i class="fa-solid fa-cart-shopping add_to_cart_icon added" data-recipe_key="{{ recipe.clean_key }}"></i>
                 </td>
             </tr>
             {% endfor %}

--- a/food_db/food_db_app/templates/main.html
+++ b/food_db/food_db_app/templates/main.html
@@ -17,5 +17,6 @@
     {% block content %}
     
     {% endblock content %}
+    <script src="{% static 'js/cart.js' %}"></script>
 </body>
 </html>

--- a/food_db/food_db_app/templates/navbar.html
+++ b/food_db/food_db_app/templates/navbar.html
@@ -16,5 +16,5 @@
 <a href="{% url 'add_recipe' %}">Add a new recipe</a> | 
 <a href="{% url 'search' %}">Recipes</a> |
 <a href="{% url 'manage_food' %}">Food Manager</a> | 
-<a href="{% url 'bulk_prep' %}">Bulk Prep</a>
+<a href="{% url 'bulk_prep' %}">Bulk Prep</a> <span {% if cart|length <= 0 %}style="display: none;" {% endif %}id="cart_size">{{ cart|length }}</span>
 <hr>

--- a/food_db/food_db_app/templates/navbar.html
+++ b/food_db/food_db_app/templates/navbar.html
@@ -14,7 +14,7 @@
 <br style="clear:both" />
 <a class="left_side_of_page" href="{% url 'index' %}">Home</a> | 
 <a href="{% url 'add_recipe' %}">Add a new recipe</a> | 
-<a href="{% url 'manage_food' %}">Food Manager</a> | 
 <a href="{% url 'search' %}">Recipes</a> |
+<a href="{% url 'manage_food' %}">Food Manager</a> | 
 <a href="{% url 'bulk_prep' %}">Bulk Prep</a>
 <hr>

--- a/food_db/food_db_app/templates/navbar.html
+++ b/food_db/food_db_app/templates/navbar.html
@@ -12,5 +12,9 @@
 </div>
 <br>
 <br style="clear:both" />
-<a class="left_side_of_page" href="{% url 'index' %}">Home</a> | <a href="{% url 'add_recipe' %}">Add a new recipe</a> | <a href="{% url 'manage_food' %}">Food Manager</a> | <a href="{% url 'search' %}">Recipes</a>
+<a class="left_side_of_page" href="{% url 'index' %}">Home</a> | 
+<a href="{% url 'add_recipe' %}">Add a new recipe</a> | 
+<a href="{% url 'manage_food' %}">Food Manager</a> | 
+<a href="{% url 'search' %}">Recipes</a> |
+<a href="{% url 'bulk_prep' %}">Bulk Prep</a>
 <hr>

--- a/food_db/food_db_app/templates/recipe_detail.html
+++ b/food_db/food_db_app/templates/recipe_detail.html
@@ -31,6 +31,7 @@
                     <path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.5 2.5 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5m-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3m11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3"/>
                 </svg>
             </a>
+            <i class="fa-solid fa-xl fa-cart-shopping add_to_cart_icon {% if in_cart == "false" %}not_{% endif %}added" data-recipe_key="{{ recipe.clean_key }}"></i>
         </td>
         <td id="upvote_button_td" class="recipe_detail_header_buttons">    
             <div id="upvote_button_div">

--- a/food_db/food_db_app/templates/search.html
+++ b/food_db/food_db_app/templates/search.html
@@ -131,7 +131,7 @@
                     <!-- <i class="fa-solid fa-cart-shopping add_to_cart_icon"></i> -->
                 </td>
                 <td style="background-color: white !important;">
-                    <i class="fa-solid fa-cart-shopping add_to_cart_icon not_added" data-recipe_key="{{ data.clean_key }}"></i>
+                    <i class="fa-solid fa-cart-shopping add_to_cart_icon {% if data.in_cart == "false" %}not_{% endif %}added" data-recipe_key="{{ data.clean_key }}"></i>
                 </td>
             </tr>
             {% endfor %}

--- a/food_db/food_db_app/templates/search.html
+++ b/food_db/food_db_app/templates/search.html
@@ -128,6 +128,10 @@
                 </td>
                 <td>
                     {{ data.date_created }}
+                    <!-- <i class="fa-solid fa-cart-shopping add_to_cart_icon"></i> -->
+                </td>
+                <td style="background-color: white !important;">
+                    <i class="fa-solid fa-cart-shopping add_to_cart_icon not_added" data-recipe_key="{{ data.clean_key }}"></i>
                 </td>
             </tr>
             {% endfor %}
@@ -135,6 +139,7 @@
     </table>
 </div>
 <script src="{% static 'js/swap_cooking_baking.js' %}"></script>
+<script src="{% static 'js/cart.js' %}"></script>
 <script src="{% static 'js/search_filter.js' %}"></script>
 <script src="{% static 'js/search_sort.js' %}"></script>
 

--- a/food_db/food_db_app/templates/search.html
+++ b/food_db/food_db_app/templates/search.html
@@ -139,7 +139,6 @@
     </table>
 </div>
 <script src="{% static 'js/swap_cooking_baking.js' %}"></script>
-<script src="{% static 'js/cart.js' %}"></script>
 <script src="{% static 'js/search_filter.js' %}"></script>
 <script src="{% static 'js/search_sort.js' %}"></script>
 

--- a/food_db/food_db_app/urls.py
+++ b/food_db/food_db_app/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('search/', views.search, name='search'),
 
     # apis
+    path('add_recipe_to_cart/', views.add_recipe_to_cart, name='add_recipe_to_cart'),
     path('add_tag/', views.add_tag, name='add_tag'),
     path('cook/', views.cook_meal, name='cook_meal'),
     path('delete_recipe_image/', views.delete_recipe_image, name='delete_recipe_image'),
@@ -46,6 +47,7 @@ urlpatterns = [
     path('ingred_parse', views.ingredient_parse_api, name='ingred_parse'),
     path('merge_food_categories/', views.merge_food_categories, name='merge_food_categories'),
     path('merge_foods/', views.merge_foods, name='merge_foods'),
+    path('remove_recipe_from_cart/', views.remove_recipe_from_cart, name='remove_recipe_from_cart'),
     path('swap_ingredient_category_order_numbers/', views.swap_ingredient_category_order_numbers, name='swap_ingredient_category_order_numbers'),
 
     # charts - this returns one JSON blob containing the data for every chart

--- a/food_db/food_db_app/urls.py
+++ b/food_db/food_db_app/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     # pages
     path('', views.index, name='index'),
     path('add/', views.add_recipe, name='add_recipe'),
+    path('bulk/', views.bulk_prep, name='bulk_prep'),
     path('food/', views.manage_food, name='manage_food'),
     path('recipe/<str:key>', views.recipe_detail, name='recipe_detail'),
     path('recipe/<str:key>/edit', views.edit_recipe, name='edit_recipe'),

--- a/food_db/food_db_app/urls.py
+++ b/food_db/food_db_app/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path('edit_baking_switch_cookie/', views.edit_baking_switch_cookie, name='edit_baking_switch_cookie'),
     path('edit_food_category/', views.edit_food_category, name='edit_food_category'),
     path('edit_food/', views.edit_food, name='edit_food'),
+    path('get_cart_size/', views.get_cart_size, name='get_cart_size'),
     path('get_ingredient_category_order_number/', views.get_ingredient_category_order_number, name='get_ingredient_category_order_number'),
     path('ingred_parse', views.ingredient_parse_api, name='ingred_parse'),
     path('merge_food_categories/', views.merge_food_categories, name='merge_food_categories'),

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -258,11 +258,24 @@ def get_is_baking_cookie(request):
     load."""
     return str(request.session.get('is_baking_mode', False))
 
+def get_cart(request):
+    """Get the cart from the session, or or initialize it as an empty list."""
+    cart = request.session.get('cart', [])
+    print(f"Current cart: {cart}")
+    
+    # If cart is None or contains None, reset it
+    if cart is None or (isinstance(cart, list) and None in cart):
+        cart = []
+        print("Reset cart due to None values")
+    
+    return cart
+
 # Create your views here.
 def index(request):
     all_charts = AllCharts()
     context = {
         'charts': list(all_charts.charts.keys()),
+        'cart': get_cart(request),
     }
     return render(request, 'index.html', context)
 
@@ -344,6 +357,7 @@ def recipe_detail(request, key):
         'has_children': recipe.has_children,
         'cloud_sync_enabled': S3_SYNC_ENABLED,
         'cloud_url': S3Sync().bucket_url,
+        'cart': get_cart(request),
     }
     return render(request, 'recipe_detail.html', context)
 
@@ -578,6 +592,7 @@ def add_recipe(request):
         'tag_list': existing_tags,
         'recipe_list': existing_recipes,
         'current_is_baking_mode': get_is_baking_cookie(request),
+        'cart': get_cart(request),
     }
 
     return render(request, 'add_edit_recipe.html', context)
@@ -590,7 +605,7 @@ def search(request):
 
     text_search_form = RecipeTextFilter(search_params, queryset=Recipe.objects.all().order_by('-_date_created'))
     found_recipes = text_search_form.qs.distinct()
-    cart = request.session.get('cart', [])
+    cart = get_cart(request)
     recipe_data = {recipe.title : {} for recipe in found_recipes}
     for recipe in found_recipes:
         recipe_data[recipe.title]['tags'] = [t['fields'] for t in json.loads(serialize('json',recipe.associated_tags))]  # convert Tag to JSON, then dict, because Tag object cannot be implicitly serialized into JSON (which is done on the search template so the data is accessible in Javascript layer)
@@ -634,6 +649,7 @@ def search(request):
         'tag_counts': tag_counts,
         'is_baking_recipe': search_params['is_baking_recipe'],
         'current_is_baking_mode': get_is_baking_cookie(request),
+        'cart': cart,
     }
     return render(request, 'search.html', context)
 
@@ -976,6 +992,7 @@ def edit_recipe(request, key):
         'recipe_list': existing_recipes,
         'child_recipes': child_recipes,
         'current_is_baking_mode': get_is_baking_cookie(request),
+        'cart': get_cart(request),
     }
 
     return render(request, 'add_edit_recipe.html', context)
@@ -1008,13 +1025,14 @@ def manage_food(request):
         'all_categories': all_categories,
         'food_search': food_search_form,
         'category_search': food_category_search_form,
+        'cart': get_cart(request),
     }
     return render(request, 'manage_food.html', context)
 
 
 def bulk_prep(request):
     context = {
-        # 'foods': foods,
+        'cart': get_cart(request),
     }
     return render(request, 'bulk_prep.html', context)
 
@@ -1261,3 +1279,11 @@ def remove_recipe_from_cart(request):
         return HttpResponse(status=200)
     else:
         return HttpResponseNotAllowed(permitted_methods=['POST'])
+
+@csrf_exempt
+def get_cart_size(request):
+    if request.method == 'GET':
+        cart = get_cart(request)
+        return HttpResponse(str(len(cart)))
+    else:
+        return HttpResponseNotAllowed(permitted_methods=['GET'])

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -357,7 +357,8 @@ def recipe_detail(request, key):
         'has_children': recipe.has_children,
         'cloud_sync_enabled': S3_SYNC_ENABLED,
         'cloud_url': S3Sync().bucket_url,
-        'cart': get_cart(request),
+        'cart': (cart := get_cart(request)),
+        'in_cart': str(recipe.clean_key in cart).lower()
     }
     return render(request, 'recipe_detail.html', context)
 

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -1211,11 +1211,27 @@ def edit_baking_switch_cookie(request):
 def add_recipe_to_cart(request):
     if request.method == 'POST':
         data = json.loads(request.body)
+        print(data)
         recipe_key = data['recipe_key']
-        if 'cart' not in (sesh := request.session):
-            sesh['cart'] = [recipe_key]
-        elif recipe_key not in sesh['cart']:
-            sesh['cart'].append(recipe_key)
+        
+        # Get cart or initialize as empty list
+        cart = request.session.get('cart', [])
+        print(f"Current cart: {cart}")
+        
+        # If cart is None or contains None, reset it
+        if cart is None or (isinstance(cart, list) and None in cart):
+            cart = []
+            print("Reset cart due to None values")
+        
+        # Add recipe if not already in cart
+        if recipe_key not in cart:
+            cart.append(recipe_key)
+            request.session['cart'] = cart
+            print(f"Added {recipe_key} to cart")
+        else:
+            print(f"{recipe_key} already in cart")
+            
+        print(f"Final cart: {request.session['cart']}")
         return HttpResponse(status=200)
     else:
         return HttpResponseNotAllowed(permitted_methods=['POST'])
@@ -1225,13 +1241,21 @@ def remove_recipe_from_cart(request):
     if request.method == 'POST':
         data = json.loads(request.body)
         recipe_key = data['recipe_key']
-        if 'cart' not in (sesh := request.session):
-            sesh['cart'] = []
-        else:
-            try:
-                sesh['cart'].remove(recipe_key)
-            except ValueError:
-                pass
+        
+        # Get cart or initialize as empty list
+        cart = request.session.get('cart', [])
+        
+        # If cart is None or contains None, reset it
+        if cart is None or (isinstance(cart, list) and None in cart):
+            cart = []
+        
+        # Remove recipe from cart
+        try:
+            cart.remove(recipe_key)
+            request.session['cart'] = cart
+        except ValueError:
+            pass  # Recipe not in cart, which is fine
+            
         return HttpResponse(status=200)
     else:
         return HttpResponseNotAllowed(permitted_methods=['POST'])

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -1010,6 +1010,13 @@ def manage_food(request):
     return render(request, 'manage_food.html', context)
 
 
+def bulk_prep(request):
+    context = {
+        # 'foods': foods,
+    }
+    return render(request, 'bulk_prep.html', context)
+
+
 @csrf_exempt
 def add_tag(request):
     if request.method == 'POST':

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -1031,8 +1031,12 @@ def manage_food(request):
 
 
 def bulk_prep(request):
+    cart = get_cart(request)
+    cart_recipes = [Recipe.objects.get(clean_key = key) for key in cart]
+
     context = {
-        'cart': get_cart(request),
+        'cart': cart,
+        'recipes': cart_recipes,
     }
     return render(request, 'bulk_prep.html', context)
 

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -590,6 +590,7 @@ def search(request):
 
     text_search_form = RecipeTextFilter(search_params, queryset=Recipe.objects.all().order_by('-_date_created'))
     found_recipes = text_search_form.qs.distinct()
+    cart = request.session.get('cart', [])
     recipe_data = {recipe.title : {} for recipe in found_recipes}
     for recipe in found_recipes:
         recipe_data[recipe.title]['tags'] = [t['fields'] for t in json.loads(serialize('json',recipe.associated_tags))]  # convert Tag to JSON, then dict, because Tag object cannot be implicitly serialized into JSON (which is done on the search template so the data is accessible in Javascript layer)
@@ -605,6 +606,7 @@ def search(request):
         else:
             recipe_data[recipe.title]['times_cooked'] = ''
             recipe_data[recipe.title]['last_cooked'] = ''
+        recipe_data[recipe.title]['in_cart'] = str(recipe.clean_key in cart).lower()
     
     # Get count of recipes by tag, used to display metadata on search page
     tag_counts = defaultdict(int)

--- a/food_db/food_db_app/views.py
+++ b/food_db/food_db_app/views.py
@@ -1206,3 +1206,32 @@ def edit_baking_switch_cookie(request):
         return HttpResponse(status=200)
     else:
         return HttpResponseNotAllowed(permitted_methods=['POST'])
+
+@csrf_exempt
+def add_recipe_to_cart(request):
+    if request.method == 'POST':
+        data = json.loads(request.body)
+        recipe_key = data['recipe_key']
+        if 'cart' not in (sesh := request.session):
+            sesh['cart'] = [recipe_key]
+        elif recipe_key not in sesh['cart']:
+            sesh['cart'].append(recipe_key)
+        return HttpResponse(status=200)
+    else:
+        return HttpResponseNotAllowed(permitted_methods=['POST'])
+
+@csrf_exempt
+def remove_recipe_from_cart(request):
+    if request.method == 'POST':
+        data = json.loads(request.body)
+        recipe_key = data['recipe_key']
+        if 'cart' not in (sesh := request.session):
+            sesh['cart'] = []
+        else:
+            try:
+                sesh['cart'].remove(recipe_key)
+            except ValueError:
+                pass
+        return HttpResponse(status=200)
+    else:
+        return HttpResponseNotAllowed(permitted_methods=['POST'])

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -960,3 +960,16 @@ details[open] summary {
 .chart {
     height: 300px;
 }
+
+.add_to_cart_icon {
+    cursor: pointer;
+    transition: color 0.2s ease-in-out, opacity 0.2s ease-in-out;
+    opacity: 0.2;
+}
+.add_to_cart_icon:hover.not_added {
+    opacity: 0.5;
+}
+.add_to_cart_icon.added {
+    color:#3cc382;
+    opacity: 1;
+}

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -973,3 +973,36 @@ details[open] summary {
     color:#3cc382;
     opacity: 1;
 }
+#cart_size {
+    position: relative;
+    display: inline-block;
+    padding-left: 0.5em; /* Space for the circle */
+    font-weight: bold;
+    z-index: 0;
+    color: #fff;
+}
+
+/* Base styles for the background shape */
+#cart_size::before {
+    content: "";
+    position: absolute;
+    left: 0.1em;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 1.4em;
+    background: #3cc382;
+    z-index: -1;
+    display: block;
+}
+
+/* Single digit: circle shape */
+#cart_size.single-digit::before {
+    width: 1.4em;
+    border-radius: 50%;
+}
+
+/* Multiple digits: stadium shape (oval with parallel top and bottom lines) */
+#cart_size.multi-digit::before {
+    width: calc(0.8em + 0.5em * var(--digit-count, 1));
+    border-radius: 0.7em;
+}

--- a/food_db/static/js/cart.js
+++ b/food_db/static/js/cart.js
@@ -1,10 +1,24 @@
-async function addRecipeToCart(event) {
-    let icon = event.target;
-    let svgParent = icon.closest('svg')
-    let recipeKey = svgParent.getAttribute('data-recipe_key')
-    console.log(`Adding recipe ${recipeKey} to cart`)
+let cartCounter = document.getElementById('cart_size')
+
+async function updateCart(event) {
+    // Find the cart icon (which has the data-recipe_key attribute)
+    let cartIcon = event.target.closest('.add_to_cart_icon')
+    let recipeKey = cartIcon.getAttribute('data-recipe_key')
     
-    let apiSuccess = await fetch(`/add_recipe_to_cart/`, {
+    let adding = cartIcon.classList.contains('not_added')
+    let logVerb
+    let apiName
+    if ( adding ) {
+        logVerb = 'Add'
+        apiName = '/add_recipe_to_cart/'
+    } else {
+        logVerb = 'Remov'
+        apiName = '/remove_recipe_from_cart/'
+    }
+
+    console.log(`Cart update: ${logVerb}ing recipe ${recipeKey}`)
+    
+    let apiSuccess = await fetch(apiName, {
         method: "POST",
         headers: {
             'Accept': 'application/json',
@@ -24,31 +38,30 @@ async function addRecipeToCart(event) {
     })
     
     if (apiSuccess) {
-        console.log(`Added successfully`)
-        svgParent.classList.remove('not_added')
-        svgParent.classList.add('added')
+        console.log(`${logVerb}ed successfully`)
+        if ( adding ) {
+            cartIcon.classList.remove('not_added')
+            cartIcon.classList.add('added')
+        } else {
+            cartIcon.classList.remove('added')
+            cartIcon.classList.add('not_added')
+        }
     }
 }
 
-function addCartIconListeners() {
-    // Add event listeners to all add to cart icons
-    let addToCartIcons = document.querySelectorAll('.add_to_cart_icon')
-    addToCartIcons.forEach(function(icon) {
-        let pathChild = icon.querySelector('path')
-        icon.addEventListener('click', function(event) {
-            // Prevent the icon click from doing anything itself,
-            // but trigger the click event on the pathChild instead
-            
-            // Only trigger if the event did not originate from the path itself
-            if (event.target !== pathChild) {
-                pathChild.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-            }
-        });
-        
-        // Add the listener to the path child
-        pathChild.addEventListener('click', addRecipeToCart)
+function addCartIconListener() {
+    // Attach listener to document body and delegate events.
+    // This way it works even if Font Awesome re-renders the SVGs,
+    // which would reset listeners
+    document.addEventListener('click', function(event) {
+        // Check if the clicked element is a cart icon or inside one
+        let cartIcon = event.target.closest('.add_to_cart_icon')
+        if (cartIcon) {
+            event.preventDefault()
+            updateCart(event)
+        }
     })
 }
 
-// Need to wait for "onload" to be after all the SVGs are rendered by Font Awesome magic
-window.addEventListener('load', addCartIconListeners)
+// Setup event delegation when page loads
+window.addEventListener('load', addCartIconListener)

--- a/food_db/static/js/cart.js
+++ b/food_db/static/js/cart.js
@@ -1,0 +1,54 @@
+async function addRecipeToCart(event) {
+    let icon = event.target;
+    let svgParent = icon.closest('svg')
+    let recipeKey = svgParent.getAttribute('data-recipe_key')
+    console.log(`Adding recipe ${recipeKey} to cart`)
+    
+    let apiSuccess = await fetch(`/add_recipe_to_cart/`, {
+        method: "POST",
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            recipe_key: recipeKey,
+        })
+    })
+    .then(function(response) {
+        if (! response.status == 200) {
+            console.log("d'oh!")
+            return false
+        } else {
+            return true
+        }
+    })
+    
+    if (apiSuccess) {
+        console.log(`Added successfully`)
+        svgParent.classList.remove('not_added')
+        svgParent.classList.add('added')
+    }
+}
+
+function addCartIconListeners() {
+    // Add event listeners to all add to cart icons
+    let addToCartIcons = document.querySelectorAll('.add_to_cart_icon')
+    addToCartIcons.forEach(function(icon) {
+        let pathChild = icon.querySelector('path')
+        icon.addEventListener('click', function(event) {
+            // Prevent the icon click from doing anything itself,
+            // but trigger the click event on the pathChild instead
+            
+            // Only trigger if the event did not originate from the path itself
+            if (event.target !== pathChild) {
+                pathChild.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+            }
+        });
+        
+        // Add the listener to the path child
+        pathChild.addEventListener('click', addRecipeToCart)
+    })
+}
+
+// Need to wait for "onload" to be after all the SVGs are rendered by Font Awesome magic
+window.addEventListener('load', addCartIconListeners)

--- a/food_db/static/js/cart.js
+++ b/food_db/static/js/cart.js
@@ -1,5 +1,20 @@
 let cartCounter = document.getElementById('cart_size')
 
+function updateCartShape(cartSize) {
+    // Remove existing shape classes
+    cartCounter.classList.remove('single-digit', 'multi-digit')
+    
+    // Set CSS custom property for digit count
+    cartCounter.style.setProperty('--digit-count', cartSize.length)
+    
+    // Add appropriate class based on number of digits
+    if (cartSize.length === 1) {
+        cartCounter.classList.add('single-digit')
+    } else {
+        cartCounter.classList.add('multi-digit')
+    }
+}
+
 async function updateCart(event) {
     // Find the cart icon (which has the data-recipe_key attribute)
     let cartIcon = event.target.closest('.add_to_cart_icon')
@@ -46,6 +61,22 @@ async function updateCart(event) {
             cartIcon.classList.remove('added')
             cartIcon.classList.add('not_added')
         }
+
+        // Update counter in nav bar
+        let cartSize = await fetch('/get_cart_size/', {
+            method: "GET",
+        })
+        .then(function(response) {
+            return response.text()
+        })
+        cartCounter.innerText = cartSize
+        if ( cartSize > 0 ) {
+            cartCounter.style.display = ''
+            // Update shape based on number of digits
+            updateCartShape(cartSize)
+        } else {
+            cartCounter.style.display = 'none'
+        }
     }
 }
 
@@ -65,3 +96,10 @@ function addCartIconListener() {
 
 // Setup event delegation when page loads
 window.addEventListener('load', addCartIconListener)
+
+// Initialize cart shape when page loads
+window.addEventListener('load', function() {
+    if ( parseInt(cartCounter.innerText) > 0 ) {
+        updateCartShape(cartCounter.innerText)
+    }
+})

--- a/food_db/static/js/search_filter.js
+++ b/food_db/static/js/search_filter.js
@@ -129,6 +129,15 @@ async function stealthSubmit(e) {
 
     // This function is defined in search_sort.js
     addListenersToTableHeaders()
+
+    // This function is defined in cart.js
+    // For Font Awesome 6.x, wait until all <i> elements are replaced by SVGs before adding cart icon listeners.
+    if (window.FontAwesome && window.FontAwesome.dom && typeof window.FontAwesome.dom.i2svg === 'function') {
+        window.FontAwesome.dom.i2svg({ callback: addCartIconListeners });
+    } else {
+        // Fallback: if FontAwesome is not ready, listen for the i2svg event
+        document.addEventListener('fa-i2svg-done', addCartIconListeners, { once: true });
+    }
 }
 
 titleSearch.addEventListener("input", stealthSubmit);

--- a/food_db/static/js/search_filter.js
+++ b/food_db/static/js/search_filter.js
@@ -129,15 +129,6 @@ async function stealthSubmit(e) {
 
     // This function is defined in search_sort.js
     addListenersToTableHeaders()
-
-    // This function is defined in cart.js
-    // For Font Awesome 6.x, wait until all <i> elements are replaced by SVGs before adding cart icon listeners.
-    if (window.FontAwesome && window.FontAwesome.dom && typeof window.FontAwesome.dom.i2svg === 'function') {
-        window.FontAwesome.dom.i2svg({ callback: addCartIconListeners });
-    } else {
-        // Fallback: if FontAwesome is not ready, listen for the i2svg event
-        document.addEventListener('fa-i2svg-done', addCartIconListeners, { once: true });
-    }
 }
 
 titleSearch.addEventListener("input", stealthSubmit);

--- a/food_db/static/js/swap_cooking_baking.js
+++ b/food_db/static/js/swap_cooking_baking.js
@@ -1,5 +1,5 @@
 let isBakingInput = document.getElementById('cooking_baking_switch');
-document.getElementById('baking_switch_label').style.display = 'inline-block'; // Make it visible on pages where this .js script is included
+document.getElementById('baking_switch_label').style.display = 'inline-block'; // The switch is hidden by default. Make it visible on pages where this .js script is included
 
 function swapCookingOrBakingTags(element) {
     if ( element == undefined ) {


### PR DESCRIPTION
Closes #85 

Creates a new page, Bulk Prep, on which I will soon build out features that help you prepare and coordinate multiple recipes at once. For now, the page just lists the recipes in your cart. 

Your cart is saved to your session. Session ID is stored in a cookie. The number of recipes in your cart are visible from any page. You can add a recipe to the cart from the Recipes/search page or its recipe detail page, and you can remove it from the cart from those pages plus the Bulk Prep page.