### PR TITLE
Create filterable line graph for tag counts over time

### DIFF
--- a/food_db/food_db_app/charts.py
+++ b/food_db/food_db_app/charts.py
@@ -29,9 +29,12 @@ class BaseChart():
             'x_labels': cls.x_labels, 
             'y_data': cls.y_data,
             'type': cls.type,
-            'step_size': 1  # default value
+            # defaults for optional attributes
+            'step_size': 1,
+            'filter_datasets': False,
         }
         optional_attributes = [
+            'filter_datasets',
             'step_size',
             'y_axis_min',
             'y_axis_max',
@@ -115,6 +118,7 @@ class TagOverTime(BaseChart):
     type = 'line'
     y_axis_min = 0
     title = 'Tag Cooks Over Time'
+    filter_datasets = True
 
     try:
         earliest_meal = CookedMeal.objects.filter(recipe__is_component_recipe=False).order_by('_date_created').first()  # ordering by date created instead of date cooked to avoid back-dated meals
@@ -146,7 +150,8 @@ class TagOverTime(BaseChart):
                 tag_dict[tag.name][cooked_date_month] += 1
         
         x_labels = list(months_dict.keys())
-        y_data = {tag_name: list(monthly_data.values()) for tag_name, monthly_data in tag_dict.items() if tag_name in ['Healthy', 'Cookies', 'Soup', 'Asian', 'Mexican', 'Bread']}
+        y_data_raw = {tag_name: list(monthly_data.values()) for tag_name, monthly_data in tag_dict.items() if tag_name in ['Healthy', 'Cookies', 'Soup', 'Asian', 'Mexican', 'Bread']}
+        y_data = OrderedDict(sorted(y_data_raw.items(), key=lambda item: item[0]))
     except OperationalError:
         # During migrations, database schema may not match models yet
         pass

--- a/food_db/food_db_app/charts.py
+++ b/food_db/food_db_app/charts.py
@@ -1,7 +1,10 @@
+from copy import deepcopy
+import pytz
 import re
 import sys
 
 from collections import defaultdict, OrderedDict
+from datetime import datetime
 from django.db.utils import OperationalError
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -107,6 +110,46 @@ class Top10BakedTags(BaseTopTags):
     baked_counts = BaseTopTags.cooked_baking_tag_counts
     x_labels = list(baked_counts.keys())[:10]
     y_data = {title: list(baked_counts.values())[:10]}
+
+class TagOverTime(BaseChart):
+    type = 'line'
+    y_axis_min = 0
+    title = 'Tag Cooks Over Time'
+
+    try:
+        earliest_meal = CookedMeal.objects.filter(recipe__is_component_recipe=False).order_by('_date_created').first()  # ordering by date created instead of date cooked to avoid back-dated meals
+        earliest_date = earliest_meal.date_cooked 
+
+        # Create a dictionary where each key is the first of a month
+        now = datetime.now(pytz.timezone('America/Los_Angeles'))
+        month_iter = earliest_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        months_dict = OrderedDict()
+        while month_iter <= last_month:
+            key = month_iter.strftime('%Y-%m')
+            # months_dict[key] = {tag: 0 for tag in all_tags}
+            months_dict[key] = 0
+            # Advance to next month
+            if month_iter.month == 12:
+                month_iter = month_iter.replace(year=month_iter.year+1, month=1)
+            else:
+                month_iter = month_iter.replace(month=month_iter.month+1)
+
+        # dataset will be split/keyed by Tag
+        tag_dict = {}
+        for tag in Tag.objects.all():
+            tag_dict[tag.name] = deepcopy(months_dict)  # doing this in a loop instead of a comprehension to ensure months_dict is always defined
+
+        for meal in CookedMeal.objects.filter(recipe__is_component_recipe=False):
+            cooked_date_month = meal.date_cooked.replace(day=1, hour=0, minute=0, second=0, microsecond=0).strftime('%Y-%m')
+            for tag in meal.recipe.associated_tags:
+                tag_dict[tag.name][cooked_date_month] += 1
+        
+        x_labels = list(months_dict.keys())
+        y_data = {tag_name: list(monthly_data.values()) for tag_name, monthly_data in tag_dict.items() if tag_name in ['Healthy', 'Cookies', 'Soup', 'Asian', 'Mexican', 'Bread']}
+    except OperationalError:
+        # During migrations, database schema may not match models yet
+        pass
 
 class AllCharts(APIView):
     def __init__(self):

--- a/food_db/food_db_app/charts.py
+++ b/food_db/food_db_app/charts.py
@@ -131,7 +131,6 @@ class TagOverTime(BaseChart):
         months_dict = OrderedDict()
         while month_iter <= last_month:
             key = month_iter.strftime('%Y-%m')
-            # months_dict[key] = {tag: 0 for tag in all_tags}
             months_dict[key] = 0
             # Advance to next month
             if month_iter.month == 12:
@@ -144,14 +143,18 @@ class TagOverTime(BaseChart):
         for tag in Tag.objects.all():
             tag_dict[tag.name] = deepcopy(months_dict)  # doing this in a loop instead of a comprehension to ensure months_dict is always defined
 
+        max_tag_count = 0
+
         for meal in CookedMeal.objects.filter(recipe__is_component_recipe=False):
             cooked_date_month = meal.date_cooked.replace(day=1, hour=0, minute=0, second=0, microsecond=0).strftime('%Y-%m')
             for tag in meal.recipe.associated_tags:
                 tag_dict[tag.name][cooked_date_month] += 1
+                max_tag_count = max(max_tag_count, tag_dict[tag.name][cooked_date_month])
         
         x_labels = list(months_dict.keys())
-        y_data_raw = {tag_name: list(monthly_data.values()) for tag_name, monthly_data in tag_dict.items() if tag_name in ['Healthy', 'Cookies', 'Soup', 'Asian', 'Mexican', 'Bread']}
+        y_data_raw = {tag_name: list(monthly_data.values()) for tag_name, monthly_data in tag_dict.items()}
         y_data = OrderedDict(sorted(y_data_raw.items(), key=lambda item: item[0]))
+        y_axis_max = max_tag_count
     except OperationalError:
         # During migrations, database schema may not match models yet
         pass

--- a/food_db/food_db_app/templates/index.html
+++ b/food_db/food_db_app/templates/index.html
@@ -7,7 +7,7 @@
     </p>
     <div class="row">
         {% for chart_id, chart_data in charts.items %}
-        <div id="{{ chart_id }}_div">
+        <div id="{{ chart_id }}_div" class="chart_container">
             <canvas class="left_side_of_page chart" id="{{ chart_id }}"></canvas>
             {% if chart_data.filter_datasets %}
                 <div class="chart_filter_box left_side_of_page">

--- a/food_db/food_db_app/templates/index.html
+++ b/food_db/food_db_app/templates/index.html
@@ -6,12 +6,22 @@
         Eventually we can put food recommendations here? Dashboards of food information? Whatever we want 🤷‍♂️
     </p>
     <div class="row">
-        {% for chart_id in charts %}
-        <div>
+        {% for chart_id, chart_data in charts.items %}
+        <div id="{{ chart_id }}_div">
             <canvas class="left_side_of_page chart" id="{{ chart_id }}"></canvas>
+            {% if chart_data.filter_datasets %}
+                <div class="chart_filter_box left_side_of_page">
+                    <ul class="chart_filter_list">
+                        {% for dataset_name in chart_data.y_data.keys %}
+                            <li class="chart_filter_item {% if forloop.first %}selected{% endif %}" data-dataset="{{ dataset_name }}">{{ dataset_name }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
         </div>
         {% endfor %}
     </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0"></script>
     <script src="{% static 'js/charts.js' %}"></script>

--- a/food_db/food_db_app/views/pages.py
+++ b/food_db/food_db_app/views/pages.py
@@ -36,7 +36,7 @@ from .utils import (
 def index(request):
     all_charts = AllCharts()
     context = {
-        'charts': list(all_charts.charts.keys()),
+        'charts': all_charts.charts,
         'cart': get_cart(request),
     }
     return render(request, 'index.html', context)

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -949,16 +949,18 @@ details[open] summary {
     color: #47d3e5;
 }
 
-/* .chart {
-    height: 300px;
-} */
-
 /* Ensure all chart containers take up the same size */
 .row > .chart_container {
     flex: 0 1 50%;
     min-width: 0;
     box-sizing: border-box;
-    /* max-width: 50%; */
+}
+/* When screen is less than 600 px wide */
+@media screen and (max-width: 599px) {
+    .row > .chart_container {
+        flex: 0 1 100%;
+        max-width: 100%;
+    }
 }
 
 /* Make chart divs with filter boxes use flexbox layout */

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -949,12 +949,38 @@ details[open] summary {
     color: #47d3e5;
 }
 
-.chart {
+/* .chart {
     height: 300px;
+} */
+
+/* Ensure all chart containers take up the same size */
+.row > .chart_container {
+    flex: 0 1 50%;
+    min-width: 0;
+    box-sizing: border-box;
+    /* max-width: 50%; */
+}
+
+/* Make chart divs with filter boxes use flexbox layout */
+.row > .chart_container:has(.chart_filter_box) {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    overflow: hidden;
+}
+
+.row > .chart_container:has(.chart_filter_box) .chart {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 0; /* Force flex to respect constraints */
+    box-sizing: border-box;
 }
 
 .chart_filter_box {
     height: 300px;
+    width: 25%;
+    flex-shrink: 0;
+    flex-grow: 0;
     border: 1px solid #ccc;
     border-radius: 5px;
     overflow-y: auto;

--- a/food_db/static/css/style.css
+++ b/food_db/static/css/style.css
@@ -953,6 +953,39 @@ details[open] summary {
     height: 300px;
 }
 
+.chart_filter_box {
+    height: 300px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    overflow-y: auto;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+.chart_filter_list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.chart_filter_item {
+    padding: 10px;
+    margin-bottom: 5px;
+    cursor: pointer;
+    border-radius: 3px;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.chart_filter_item.selected {
+    background-color: #3cc382;
+    color: white;
+}
+
+.chart_filter_item:hover {
+    background-color: #4040cc;
+    color:  white;
+}
+
 .add_to_cart_icon {
     cursor: pointer;
     transition: color 0.2s ease-in-out, opacity 0.2s ease-in-out;

--- a/food_db/static/js/charts.js
+++ b/food_db/static/js/charts.js
@@ -1,6 +1,26 @@
 let endpoint = '/charts';
 let chartInstances = {};
 
+function setCanvasSize(canvas) {
+    // Set canvas dimensions using HTML attributes (not CSS) as the charts get squished otherwise
+    let container = canvas.closest('.chart_container');
+    if (container && container.querySelector('.chart_filter_box')) {
+        // For charts with filter boxes, calculate available width
+        let containerRect = container.getBoundingClientRect();
+        let filterBox = container.querySelector('.chart_filter_box');
+        let filterBoxRect = filterBox.getBoundingClientRect();
+        let gap = 10; // gap from CSS
+        let availableWidth = Math.floor(containerRect.width - filterBoxRect.width - gap);
+        canvas.setAttribute('width', availableWidth);
+        canvas.setAttribute('height', 300);
+    } else {
+        // For charts without filter boxes, use container width
+        let containerRect = container ? container.getBoundingClientRect() : canvas.parentElement.getBoundingClientRect();
+        canvas.setAttribute('width', Math.floor(containerRect.width));
+        canvas.setAttribute('height', 300);
+    }
+}
+
 async function onLoadSetup() {
     await fetch(endpoint, {
         method: "GET",
@@ -32,7 +52,10 @@ async function onLoadSetup() {
 }
 
 function drawLineGraph(data, id) {
-    let ctx = document.getElementById(id).getContext('2d');
+    let canvas = document.getElementById(id);
+    setCanvasSize(canvas);
+    
+    let ctx = canvas.getContext('2d');
     let datasets = []
     Object.keys(data.y_data).forEach(dataLabel => {
         let dataset = {
@@ -50,6 +73,8 @@ function drawLineGraph(data, id) {
             datasets: datasets,
         },
         options: {
+            responsive: false,
+            maintainAspectRatio: false,
             scales: {
                 y: {
                     min: data.y_axis_min,
@@ -70,7 +95,10 @@ function drawLineGraph(data, id) {
 }
 
 function drawBarGraph(data, id) {
-    let ctx = document.getElementById(id).getContext('2d');
+    let canvas = document.getElementById(id);
+    setCanvasSize(canvas);
+    
+    let ctx = canvas.getContext('2d');
     let datasets = []
     Object.keys(data.y_data).forEach(dataLabel => {
         let dataset = {
@@ -104,6 +132,8 @@ function drawBarGraph(data, id) {
             
         },
         options: {
+            responsive: false,
+            maintainAspectRatio: false,
             scales: {
                 y: {
                     min: data.y_axis_min,

--- a/food_db/static/js/charts.js
+++ b/food_db/static/js/charts.js
@@ -1,4 +1,5 @@
 let endpoint = '/charts';
+let chartInstances = {};
 
 async function onLoadSetup() {
     await fetch(endpoint, {
@@ -14,9 +15,14 @@ async function onLoadSetup() {
         Object.keys(data).forEach(key => {
             let chart = data[key]
             if (chart['type'] == 'line') {
-                drawLineGraph(chart, chart.element_id);
+                let chartInstance = drawLineGraph(chart, chart.element_id);
+                chartInstances[chart.element_id] = chartInstance;
             } else if (chart['type'] == 'bar') {
-                drawBarGraph(chart, chart.element_id);
+                let chartInstance = drawBarGraph(chart, chart.element_id);
+                chartInstances[chart.element_id] = chartInstance;
+            }
+            if (chart.filter_datasets) {
+                setupDatasetFilter(chart.element_id);
             }
         });
     })
@@ -33,7 +39,7 @@ function drawLineGraph(data, id) {
             label: dataLabel,
             backgroundColor: 'rgb(255, 100, 200)',
             borderColor: 'rgb(55, 99, 132)',
-            data: data.y_data[datalabel],
+            data: data.y_data[dataLabel],
         }
         datasets.push(dataset)
     })
@@ -52,10 +58,15 @@ function drawLineGraph(data, id) {
                         stepSize: data.step_size,
                     }
                 }
+            },
+            plugins: {
+                legend: {
+                    display: !data.filter_datasets,
+                }
             }
         }
-
     });
+    return chart;
 }
 
 function drawBarGraph(data, id) {
@@ -104,6 +115,45 @@ function drawBarGraph(data, id) {
             }
         }
     });
+    return myChart;
+}
+
+function setupDatasetFilter(chartId) {
+    let chartDiv = document.getElementById(`${chartId}_div`);
+    let filterItems = chartDiv.querySelectorAll('.chart_filter_item');
+    
+    filterItems.forEach(item => {
+        item.addEventListener('click', function() {
+            let selectedDataset = this.getAttribute('data-dataset');
+            
+            // Remove selected class from all items
+            filterItems.forEach(li => li.classList.remove('selected'));
+            
+            // Add selected class to clicked item
+            this.classList.add('selected');
+            
+            // Filter the chart
+            filterChartByDataset(chartId, selectedDataset);
+        });
+    });
+    
+    // Initially filter to show only the first item
+    let firstDataset = filterItems[0].getAttribute('data-dataset');
+    filterChartByDataset(chartId, firstDataset);
+}
+
+function filterChartByDataset(chartId, selectedDataset) {
+    let chart = chartInstances[chartId];
+    // Hide all datasets except the selected one
+    chart.data.datasets.forEach(dataset => {
+        if (dataset.label === selectedDataset) {
+            dataset.hidden = false;
+        } else {
+            dataset.hidden = true;
+        }
+    });
+    
+    chart.update();
 }
 
 window.addEventListener('load', onLoadSetup)


### PR DESCRIPTION
Progresses the ultimate goals in #78

Graph comes with a scrollable text box with each tag name, and clicking a tag name will filter the graph. At the moment, only one tag can be selected at a time, and they're sorted alphabetically, which is a little different than what I wanted for #78.